### PR TITLE
infra: finalize local Redis setup and cache documentation

### DIFF
--- a/docs/architecture/cache-strategy.md
+++ b/docs/architecture/cache-strategy.md
@@ -1,0 +1,42 @@
+# Cache Strategy
+
+## Overview
+
+PulseStream uses Redis as a lightweight in-memory data store for local development and future platform capabilities.
+
+At the current stage of the project, Redis is provisioned as part of the local platform environment but is not yet heavily used by application services.
+
+---
+
+## Intended Use Cases
+
+Redis may be used for:
+
+- caching frequently requested query results
+- temporary storage of derived device state
+- rate limiting support
+- lightweight coordination or ephemeral state if needed
+
+---
+
+## Current Scope
+
+For the MVP infrastructure phase, Redis is introduced to ensure that the local platform environment includes a ready-to-use caching component.
+
+This allows future services to integrate Redis without requiring additional infrastructure changes.
+
+---
+
+## Connection Details
+
+### From inside Docker network
+
+```text
+redis:6379
+```
+
+### From host machine
+
+```text
+localhost:6379
+```

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -76,11 +76,11 @@ services:
     container_name: pulsestream-redis
     ports:
       - "${REDIS_PORT:-6379}:6379"
-    command: ["redis-server", "--appendonly", "yes"]
+    command: [ "redis-server", "--appendonly", "yes" ]
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
Finalize the local Redis setup for PulseStream and document its intended role in the platform.

## Related Issue
Closes #11 

## Changes
- refine Redis service configuration in Docker Compose
- ensure Redis healthcheck and persistence are configured
- document Redis usage in local platform docs
- add cache strategy documentation for future service integration

## Testing
- started Redis locally using Docker Compose
- verified health with `redis-cli ping`
- verified Docker network connectivity using Redis service name

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Documentation updated if needed
- [x] Linked issue is referenced