### PR TITLE
feat: Add Docker Compose setup for a local development environment in…

### DIFF
--- a/infrastructure/docker/README.md
+++ b/infrastructure/docker/README.md
@@ -18,6 +18,7 @@ The local platform includes:
 - `docker-compose.yml` — local platform definition
 - `.env.example` — example environment configuration
 - `prometheus/prometheus.yml` — `Prometheus` configuration
+- `postgres/init.sql` — `PostgreSQL` initialization (schema and tables)
 
 ### Usage
 
@@ -70,3 +71,6 @@ docker compose down -v
 - Internal `Docker` network communication uses the `kafka:29092` listener.
 - `Prometheus` is initialized with a minimal configuration and will be extended when application services are added.
 - `Grafana` uses the credentials defined in `.env`.
+- `PostgreSQL` is initialized with the PulseStream platform schema and initial tables for telemetry and anomalies.
+- The `postgres/init.sql` script is executed when the container starts for the first time.
+- The platform uses the `platform` schema to store processed events.

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pulsestream} -d ${POSTGRES_DB:-pulsestream}"]
       interval: 10s

--- a/infrastructure/docker/postgres/init.sql
+++ b/infrastructure/docker/postgres/init.sql
@@ -1,0 +1,52 @@
+-- PulseStream Database Initialization Script
+-- This script creates the platform schema and initial tables for processed events.
+
+-- 1. Create the platform schema
+CREATE SCHEMA IF NOT EXISTS platform;
+
+-- 2. Create the processed_telemetry table
+-- This table stores enriched and normalized telemetry events.
+CREATE TABLE IF NOT EXISTS platform.processed_telemetry (
+    id SERIAL PRIMARY KEY,
+    event_id VARCHAR(50) NOT NULL UNIQUE,
+    tenant_id VARCHAR(100) NOT NULL,
+    event_type VARCHAR(50) NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    source VARCHAR(100) NOT NULL,
+    device_id VARCHAR(100) NOT NULL,
+    device_type VARCHAR(100) NOT NULL,
+    metric VARCHAR(100) NOT NULL,
+    value NUMERIC(18, 4) NOT NULL,
+    unit VARCHAR(20) NOT NULL,
+    location VARCHAR(100) NOT NULL,
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Optimize queries by tenant, device, and time
+CREATE INDEX IF NOT EXISTS idx_telemetry_tenant ON platform.processed_telemetry (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_telemetry_device ON platform.processed_telemetry (device_id);
+CREATE INDEX IF NOT EXISTS idx_telemetry_timestamp ON platform.processed_telemetry (timestamp DESC);
+
+-- 3. Create the anomalies table
+-- This table stores detected anomalies from the telemetry processor.
+CREATE TABLE IF NOT EXISTS platform.anomalies (
+    id SERIAL PRIMARY KEY,
+    event_id VARCHAR(50) NOT NULL UNIQUE,
+    tenant_id VARCHAR(100) NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    device_id VARCHAR(100) NOT NULL,
+    metric VARCHAR(100) NOT NULL,
+    value NUMERIC(18, 4) NOT NULL,
+    threshold NUMERIC(18, 4) NOT NULL,
+    anomaly_type VARCHAR(50) NOT NULL,
+    severity VARCHAR(20) NOT NULL,
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Optimize queries by tenant, device, and time for anomalies
+CREATE INDEX IF NOT EXISTS idx_anomalies_tenant ON platform.anomalies (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_anomalies_device ON platform.anomalies (device_id);
+CREATE INDEX IF NOT EXISTS idx_anomalies_timestamp ON platform.anomalies (timestamp DESC);
+
+-- 4. Initial seed data (optional, but useful for testing)
+-- Could add some sample data if needed.


### PR DESCRIPTION
## Summary
This Pull Request initializes the PostgreSQL persistence layer for the PulseStream platform. It configures the database container with a dedicated platform schema and the initial tables required to store processed telemetry and anomaly events.

## Related Issue
Closes #10 

## Changes

- Created infrastructure/docker/postgres/init.sql with the platform schema and optimized table definitions for telemetry and anomalies.
Updated 

- infrastructure/docker/docker-compose.yml to mount the initialization script, ensuring the database environment is bootstrapped automatically on container startup.

- Updated the  infrastructure README to document the database initialization process and the resulting schema layout.

- Added database indexes on tenant_id, device_id, and timestamp fields to ensure efficient querying for future analytics.

## Testing

- Verified the Docker Compose volume mount path against the standard [Postgres DockerHub](https://hub.docker.com/_/postgres) entrypoint specifications.

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [ ] Documentation updated if needed
- [x] Linked issue is referenced
