### PR TITLE
docs: align diagrams with Kafka topic naming and fix diagram references

### DIFF
--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -4,10 +4,10 @@ This directory contains the core architecture diagrams for PulseStream.
 
 ## Available Diagrams
 
-- [System Architecture](./system_architecture_diagram.md)
-- [Event Flow](./event_flow_diagram.md)
-- [Kafka Topology](./kafka_topology.md)
-- [Kubernetes Deployment](./kubernetes_deployment.md)
+- [System Architecture](./system-architecture.md)
+- [Event Flow](./event-flow.md)
+- [Kafka Topology](./kafka-topology.md)
+- [Kubernetes Deployment](./kubernetes-deployment.md)
 
 ## Purpose
 

--- a/docs/diagrams/event-flow.md
+++ b/docs/diagrams/event-flow.md
@@ -6,18 +6,20 @@ This diagram illustrates the lifecycle of a telemetry event as it moves through 
 sequenceDiagram
     participant Device as IoT Device / Simulator
     participant Ingestion as Ingestion Service
-    participant Kafka as Kafka Topic: telemetry.raw
+    participant KafkaRaw as Kafka Topic: telemetry.events.raw
     participant Processor as Telemetry Processor
+    participant KafkaOut as Kafka Topics: processed / anomalies
     participant DB as PostgreSQL
     participant Query as Query Service
     participant Dashboard as Dashboard / API Client
 
     Device->>Ingestion: POST /telemetry event
     Ingestion->>Ingestion: Validate schema
-    Ingestion->>Kafka: Publish telemetry.reading
-    Kafka->>Processor: Consume telemetry.reading
+    Ingestion->>KafkaRaw: Publish telemetry.reading
+    KafkaRaw->>Processor: Consume telemetry.reading
     Processor->>Processor: Normalize reading
     Processor->>Processor: Apply anomaly detection
+    Processor->>KafkaOut: Publish processed / anomaly events
     Processor->>DB: Store processed telemetry
     Processor->>DB: Store anomaly record (if detected)
     Query->>DB: Read telemetry and anomaly data
@@ -30,4 +32,5 @@ sequenceDiagram
 *   The platform receives telemetry over HTTP through the ingestion service.
 *   Kafka decouples telemetry producers from downstream consumers.
 *   The telemetry processor applies anomaly detection rules asynchronously.
+*   The processor publishes results to output topics (`telemetry.events.processed`, `telemetry.events.anomalies`) before persisting to PostgreSQL.
 *   Processed results are stored in PostgreSQL and later exposed through query APIs.

--- a/docs/diagrams/kafka-topology.md
+++ b/docs/diagrams/kafka-topology.md
@@ -5,31 +5,31 @@ This diagram shows how PulseStream uses Kafka topics to decouple producers and c
 ```mermaid
 flowchart LR
     A[IoT Devices / Simulator] --> B[Ingestion Service]
-    B --> T1[(telemetry.raw)]
+    B --> T1[(telemetry.events.raw)]
 
     T1 --> C[Telemetry Processor]
 
-    C --> T2[(telemetry.processed)]
-    C --> T3[(telemetry.anomalies)]
-    C --> T4[(telemetry.deadletter)]
+    C --> T2[(telemetry.events.processed)]
+    C --> T3[(telemetry.events.anomalies)]
+    C --> T4[(telemetry.events.dlq)]
 
     T2 --> D[Query Service / Downstream Consumers]
-    T3 --> E[Alerting / Dashboard / Query Service]
+    T3 --> E[Query Service / Monitoring Dashboards / Future Alerting]
     T4 --> F[DLQ Inspection / Replay Tools]
 ```
 
 ### Topic Definitions
 
-| Topic                | Producer                                | Consumer                                  | Purpose                           |
-|----------------------|-----------------------------------------|-------------------------------------------|-----------------------------------|
-| `telemetry.raw`      | Ingestion Service                       | Telemetry Processor                       | Raw incoming telemetry events     |
-| `telemetry.processed`| Telemetry Processor                     | Query Service / downstream consumers      | Normalized and enriched telemetry data |
-| `telemetry.anomalies`| Telemetry Processor                     | Dashboard / alerting / query service      | Detected anomaly events           |
-| `telemetry.deadletter`| Ingestion Service or Telemetry Processor | Replay or inspection tools                | Invalid or failed events          |
+| Topic                        | Producer                                | Consumer                                  | Purpose                           |
+|------------------------------|-----------------------------------------|-------------------------------------------|-----------------------------------|
+| `telemetry.events.raw`       | Ingestion Service                       | Telemetry Processor                       | Raw incoming telemetry events     |
+| `telemetry.events.processed` | Telemetry Processor                     | Query Service / downstream consumers      | Normalized and enriched telemetry data |
+| `telemetry.events.anomalies` | Telemetry Processor                     | Query Service / Monitoring Dashboards / Future Alerting | Detected anomaly events           |
+| `telemetry.events.dlq`       | Ingestion Service or Telemetry Processor | Replay or inspection tools                | Invalid or failed events          |
 
 ### Notes
 
-*   `telemetry.raw` is the primary ingestion topic.
-*   `telemetry.processed` allows downstream consumers to use cleaned telemetry without duplicating processing logic.
-*   `telemetry.anomalies` isolates anomaly events from normal telemetry flow.
-*   `telemetry.deadletter` supports resilience and recovery workflows.
+*   `telemetry.events.raw` is the primary ingestion topic.
+*   `telemetry.events.processed` allows downstream consumers to use cleaned telemetry without duplicating processing logic.
+*   `telemetry.events.anomalies` isolates anomaly events from normal telemetry flow.
+*   `telemetry.events.dlq` supports resilience and recovery workflows.

--- a/docs/diagrams/kubernetes-deployment.md
+++ b/docs/diagrams/kubernetes-deployment.md
@@ -8,12 +8,12 @@ flowchart TB
 
     subgraph Kubernetes Cluster
         I --> S1[Ingestion Service Pod]
-        S1 --> K1[(Kafka: telemetry.raw)]
+        S1 --> K1[(Kafka: telemetry.events.raw)]
 
         K1 --> S2[Telemetry Processor Pod]
-        S2 --> K2[(Kafka: telemetry.processed)]
-        S2 --> K3[(Kafka: telemetry.anomalies)]
-        S2 --> K4[(Kafka: telemetry.deadletter)]
+        S2 --> K2[(Kafka: telemetry.events.processed)]
+        S2 --> K3[(Kafka: telemetry.events.anomalies)]
+        S2 --> K4[(Kafka: telemetry.events.dlq)]
 
         S2 --> DB[(PostgreSQL)]
 

--- a/docs/diagrams/system-architecture.md
+++ b/docs/diagrams/system-architecture.md
@@ -5,12 +5,12 @@ This diagram shows the high-level architecture of PulseStream and the main inter
 ```mermaid
 flowchart LR
     A[IoT Devices / Simulator] --> B[Ingestion Service]
-    B --> T1[(Kafka Topic: telemetry.raw)]
+    B --> T1[(Kafka Topic: telemetry.events.raw)]
 
     T1 --> C[Telemetry Processor]
-    C --> T2[(Kafka Topic: telemetry.processed)]
-    C --> T3[(Kafka Topic: telemetry.anomalies)]
-    C --> T4[(Kafka Topic: telemetry.deadletter)]
+    C --> T2[(Kafka Topic: telemetry.events.processed)]
+    C --> T3[(Kafka Topic: telemetry.events.anomalies)]
+    C --> T4[(Kafka Topic: telemetry.events.dlq)]
 
     C --> D[PostgreSQL]
     D --> E[Query Service]
@@ -37,10 +37,10 @@ flowchart LR
 
 **Notes:**
 
-*   `telemetry.raw` stores incoming telemetry readings.
+*   `telemetry.events.raw` stores incoming telemetry readings.
 
-*   `telemetry.processed` stores normalized or enriched downstream events.
+*   `telemetry.events.processed` stores normalized or enriched downstream events.
 
-*   `telemetry.anomalies` captures anomaly detection results.
+*   `telemetry.events.anomalies` captures anomaly detection results.
 
-*   `telemetry.deadletter` stores invalid or failed events.
+*   `telemetry.events.dlq` stores invalid or failed events.


### PR DESCRIPTION
## Summary
Align all architecture diagrams with the updated Kafka topic naming convention and fix diagram inconsistencies.

## Related Issue
Closes #56 

## Changes
- update Kafka topic names across all diagrams:
  - telemetry.events.raw
  - telemetry.events.processed
  - telemetry.events.anomalies
  - telemetry.events.dlq
- update event flow diagram to include processor outputs
- fix incorrect file references in docs/diagrams/README.md
- align anomaly consumers with current MVP scope

## Testing
- visually verified Mermaid diagrams render correctly
- ensured topic naming consistency across:
  - architecture docs
  - diagrams
- validated diagram links in README

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Documentation updated if needed
- [x] Linked issue is referenced