### PR TITLE
chore: complete ingestion-service base configuration

### DIFF
--- a/services/ingestion-service/src/main/resources/application.yml
+++ b/services/ingestion-service/src/main/resources/application.yml
@@ -18,3 +18,12 @@ logging:
   level:
     root: INFO
     com.pulsestream.ingestion: INFO
+
+pulsestream:
+  kafka:
+    bootstrap-servers: localhost:9092
+    topics:
+      raw: telemetry.events.raw
+      processed: telemetry.events.processed
+      anomalies: telemetry.events.anomalies
+      dlq: telemetry.events.dlq


### PR DESCRIPTION
## Summary
Complete the base `application.yml` configuration for the ingestion-service by adding the missing Kafka placeholder configuration required by the issue.

## Related Issue
Closes #63

## Issue Requirements Covered
- add placeholder Kafka config section for future work
- keep configuration readable and extensible
- preserve base runtime configuration for local development and service identity

## Changes
- add `pulsestream.kafka.bootstrap-servers` to `application.yml`
- add topic placeholders for:
  - `telemetry.events.raw`
  - `telemetry.events.processed`
  - `telemetry.events.anomalies`
  - `telemetry.events.dlq`
- keep the existing service name, server port, actuator exposure, and logging baseline unchanged

## Testing
Verified the configuration file structure manually and confirmed the added keys align with the architecture documentation and topic naming convention. The change is configuration-only and remains within the existing ingestion-service startup configuration.

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope

## Summary by Sourcery

Add placeholder Kafka configuration for the ingestion-service to support future telemetry event topics while preserving existing runtime settings.

New Features:
- Introduce base Kafka configuration section with bootstrap servers in the ingestion-service application YAML.
- Define placeholder telemetry event topics for raw, processed, and anomaly streams in the ingestion-service configuration.