### PR TITLE
feat(ingestion-service): add Dockerfile (#65)

### DIFF
--- a/services/ingestion-service/.dockerignore
+++ b/services/ingestion-service/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.git
+.gitignore
+node_modules
+Dockerfile
+README.md

--- a/services/ingestion-service/Dockerfile
+++ b/services/ingestion-service/Dockerfile
@@ -1,0 +1,23 @@
+FROM maven:3.9.9-eclipse-temurin-17 AS builder
+
+WORKDIR /app
+
+COPY pom.xml .
+
+RUN mvn -B -q -e -DskipTests dependency:go-offline
+
+COPY src ./src
+
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/services/ingestion-service/Dockerfile
+++ b/services/ingestion-service/Dockerfile
@@ -1,23 +1,36 @@
+
 FROM maven:3.9.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
 
 COPY pom.xml .
-
 RUN mvn -B -q -e -DskipTests dependency:go-offline
 
 COPY src ./src
-
 RUN mvn clean package -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+RUN java -Djarmode=layertools -jar target/*.jar extract
+
+
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 
-COPY --from=builder /app/target/*.jar app.jar
+RUN groupadd -r spring && useradd -r -g spring spring
+
+# Copy layers separately (better caching)
+COPY --from=builder /app/dependencies/ ./
+COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --from=builder /app/spring-boot-loader/ ./
+COPY --from=builder /app/application/ ./
+
+# Set ownership
+RUN chown -R spring:spring /app
+
+USER spring:spring
 
 EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher"]


### PR DESCRIPTION
## Summary
Add a production-ready multi-stage Dockerfile for the ingestion-service to enable containerized execution.

## Related Issue
Closes #65

## Changes
- Added multi-stage Dockerfile using Maven build + JRE runtime
- Optimized build layers using dependency caching
- Configured container-friendly JVM options
- Exposed application port

## Testing
- Built Docker image locally
- Ran container and verified application startup
- Verified /actuator/health endpoint returns UP

## Checklist
- [x] Builds successfully
- [x] Runs locally via Docker
- [x] Follows project structure conventions
- [x] Linked to issue

## Summary by Sourcery

Build:
- Introduce a multi-stage Dockerfile for ingestion-service using Maven for build and a lightweight JRE image for runtime, with JVM options and port exposure configured.