### PR TITLE
build(ingestion-service): add spring-kafka dependency

### DIFF
--- a/services/ingestion-service/pom.xml
+++ b/services/ingestion-service/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
The purpose of this pull request is to integrate the spring-kafka library into the ingestion-service. This provides the necessary infrastructure to implement Kafka producers for publishing telemetry events in subsequent tasks.

## Related Issue
Closes #71

## Issue Requirements Covered
- Added Spring Kafka dependency to the ingestion-service project.
- Verified that the dependency is managed by the Spring Boot BOM (version 3.3.5) for compatibility.
- Ensured the project is ready for upcoming producer and topic configuration.

## Changes
- Modified services/ingestion-service/pom.xml to include the org.springframework.kafka:spring-kafka dependency.

## Testing
- **Maven Build**: Executed `.\mvnw.cmd clean package -DskipTests` to ensure the project compiles and packages correctly with the new dependency.
- **Unit Tests**: Executed `.\mvnw.cmd test` to confirm that all existing tests in the ingestion service pass without regression.

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [ ] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope
