### PR TITLE
feat: implement telemetry ingestion controller with validation DTOs a…

### DIFF
--- a/services/ingestion-service/.gitignore
+++ b/services/ingestion-service/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 target/
+.m2/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/services/ingestion-service/.gitignore
+++ b/services/ingestion-service/.gitignore
@@ -1,6 +1,6 @@
 HELP.md
 target/
-.m2/
+gggggggggggggggggggggtttttt.m2/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/services/ingestion-service/.gitignore
+++ b/services/ingestion-service/.gitignore
@@ -1,6 +1,5 @@
 HELP.md
-target/
-gggggggggggggggggggggtttttt.m2/
+target/ 
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
@@ -2,12 +2,10 @@ package com.pulsestream.ingestion.controller;
 
 import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
 import jakarta.validation.Valid;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@Validated
 @RequestMapping("/api/v1/events")
 public class TelemetryController {
 

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
@@ -2,11 +2,12 @@ package com.pulsestream.ingestion.controller;
 
 import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
 import jakarta.validation.Valid;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Validated
 @RequestMapping("/api/v1/events")
 public class TelemetryController {
 

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryIngestionRequestDto.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryIngestionRequestDto.java
@@ -10,11 +10,13 @@ import java.time.Instant;
  * Request DTO for telemetry events received by the ingestion API.
  */
 public record TelemetryIngestionRequestDto(
-        @NotBlank String eventId,
-        @NotBlank String tenantId,
-        @NotBlank String eventType,
-        @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING) Instant timestamp,
-        @NotBlank String source,
-        @NotBlank String version,
-        @NotNull @Valid TelemetryPayloadDto payload) {
+        @NotBlank(message = "eventId is required") String eventId,
+        @NotBlank(message = "tenantId is required") String tenantId,
+        @NotBlank(message = "eventType is required") String eventType,
+        @NotNull(message = "timestamp is required")
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        Instant timestamp,
+        @NotBlank(message = "source is required") String source,
+        @NotBlank(message = "version is required") String version,
+        @NotNull(message = "payload is required") @Valid TelemetryPayloadDto payload) {
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryIngestionRequestDto.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryIngestionRequestDto.java
@@ -10,13 +10,13 @@ import java.time.Instant;
  * Request DTO for telemetry events received by the ingestion API.
  */
 public record TelemetryIngestionRequestDto(
-        @NotBlank(message = "eventId is required") String eventId,
-        @NotBlank(message = "tenantId is required") String tenantId,
-        @NotBlank(message = "eventType is required") String eventType,
-        @NotNull(message = "timestamp is required")
+        @NotBlank(message = ValidationMessages.EVENT_ID_REQUIRED) String eventId,
+        @NotBlank(message = ValidationMessages.TENANT_ID_REQUIRED) String tenantId,
+        @NotBlank(message = ValidationMessages.EVENT_TYPE_REQUIRED) String eventType,
+        @NotNull(message = ValidationMessages.TIMESTAMP_REQUIRED)
         @JsonFormat(shape = JsonFormat.Shape.STRING)
         Instant timestamp,
-        @NotBlank(message = "source is required") String source,
-        @NotBlank(message = "version is required") String version,
-        @NotNull(message = "payload is required") @Valid TelemetryPayloadDto payload) {
+        @NotBlank(message = ValidationMessages.SOURCE_REQUIRED) String source,
+        @NotBlank(message = ValidationMessages.VERSION_REQUIRED) String version,
+        @NotNull(message = ValidationMessages.PAYLOAD_REQUIRED) @Valid TelemetryPayloadDto payload) {
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryPayloadDto.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryPayloadDto.java
@@ -8,10 +8,10 @@ import java.math.BigDecimal;
  * Payload DTO for telemetry reading events.
  */
 public record TelemetryPayloadDto(
-        @NotBlank(message = "deviceId is required") String deviceId,
-        @NotBlank(message = "deviceType is required") String deviceType,
-        @NotBlank(message = "metric is required") String metric,
-        @NotNull(message = "value is required") BigDecimal value,
-        @NotBlank(message = "unit is required") String unit,
-        @NotBlank(message = "location is required") String location) {
+        @NotBlank(message = ValidationMessages.DEVICE_ID_REQUIRED) String deviceId,
+        @NotBlank(message = ValidationMessages.DEVICE_TYPE_REQUIRED) String deviceType,
+        @NotBlank(message = ValidationMessages.METRIC_REQUIRED) String metric,
+        @NotNull(message = ValidationMessages.VALUE_REQUIRED) BigDecimal value,
+        @NotBlank(message = ValidationMessages.UNIT_REQUIRED) String unit,
+        @NotBlank(message = ValidationMessages.LOCATION_REQUIRED) String location) {
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryPayloadDto.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/TelemetryPayloadDto.java
@@ -8,10 +8,10 @@ import java.math.BigDecimal;
  * Payload DTO for telemetry reading events.
  */
 public record TelemetryPayloadDto(
-        @NotBlank String deviceId,
-        @NotBlank String deviceType,
-        @NotBlank String metric,
-        @NotNull BigDecimal value,
-        @NotBlank String unit,
-        @NotBlank String location) {
+        @NotBlank(message = "deviceId is required") String deviceId,
+        @NotBlank(message = "deviceType is required") String deviceType,
+        @NotBlank(message = "metric is required") String metric,
+        @NotNull(message = "value is required") BigDecimal value,
+        @NotBlank(message = "unit is required") String unit,
+        @NotBlank(message = "location is required") String location) {
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/ValidationMessages.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/dto/ValidationMessages.java
@@ -1,0 +1,24 @@
+package com.pulsestream.ingestion.dto;
+
+/**
+ * Shared validation messages for ingestion request DTOs.
+ */
+public final class ValidationMessages {
+
+    public static final String EVENT_ID_REQUIRED = "eventId is required";
+    public static final String TENANT_ID_REQUIRED = "tenantId is required";
+    public static final String EVENT_TYPE_REQUIRED = "eventType is required";
+    public static final String TIMESTAMP_REQUIRED = "timestamp is required";
+    public static final String SOURCE_REQUIRED = "source is required";
+    public static final String VERSION_REQUIRED = "version is required";
+    public static final String PAYLOAD_REQUIRED = "payload is required";
+    public static final String DEVICE_ID_REQUIRED = "deviceId is required";
+    public static final String DEVICE_TYPE_REQUIRED = "deviceType is required";
+    public static final String METRIC_REQUIRED = "metric is required";
+    public static final String VALUE_REQUIRED = "value is required";
+    public static final String UNIT_REQUIRED = "unit is required";
+    public static final String LOCATION_REQUIRED = "location is required";
+
+    private ValidationMessages() {
+    }
+}

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -41,8 +43,8 @@ class TelemetryControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("should reject invalid telemetry request when required field is missing")
-    void shouldRejectInvalidTelemetryRequestWhenEventIdMissing() throws Exception {
+    @DisplayName("should reject invalid telemetry request when top-level and nested required fields are missing")
+    void shouldRejectInvalidTelemetryRequestWhenRequiredFieldsAreMissing() throws Exception {
         String requestBody = """
             {
               "tenantId": "factory-01",
@@ -52,7 +54,6 @@ class TelemetryControllerTest {
               "version": "1.0",
               "payload": {
                 "deviceId": "sensor-1042",
-                "deviceType": "temperature-sensor",
                 "metric": "temperature",
                 "value": 28.4,
                 "unit": "C",
@@ -65,7 +66,8 @@ class TelemetryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("eventId")));
+                .andExpect(jsonPath("$.errors[*].field", hasItems("eventId", "payload.deviceType")))
+                .andExpect(jsonPath("$.errors[*].message", hasItems("eventId is required", "deviceType is required")));
     }
 
     @Test
@@ -79,7 +81,9 @@ class TelemetryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Malformed JSON request body or missing required payload."));
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.path").value("/api/v1/events"))
+                .andExpect(jsonPath("$.errors", hasSize(0)));
     }
 
     @Test
@@ -101,7 +105,93 @@ class TelemetryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("payload.deviceId")));
+                .andExpect(jsonPath("$.errors[*].field", hasItem("payload.deviceId")))
+                .andExpect(jsonPath("$.errors[*].message", hasItem("deviceId is required")));
+    }
+
+    @Test
+    @DisplayName("should reject invalid telemetry request when payload is null")
+    void shouldRejectInvalidTelemetryRequestWhenPayloadIsNull() throws Exception {
+        String requestBody = """
+            {
+              "eventId": "evt-1001",
+              "tenantId": "factory-01",
+              "eventType": "telemetry.reading",
+              "timestamp": "2026-03-31T12:00:00Z",
+              "source": "sensor-gateway",
+              "version": "1.0",
+              "payload": null
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[*].field", hasItem("payload")))
+                .andExpect(jsonPath("$.errors[*].message", hasItem("payload is required")));
+    }
+
+    @Test
+    @DisplayName("should reject invalid telemetry request when required string fields are blank")
+    void shouldRejectInvalidTelemetryRequestWhenRequiredStringFieldsAreBlank() throws Exception {
+        String requestBody = """
+            {
+              "eventId": "",
+              "tenantId": " ",
+              "eventType": "telemetry.reading",
+              "timestamp": "2026-03-31T12:00:00Z",
+              "source": "sensor-gateway",
+              "version": "1.0",
+              "payload": {
+                "deviceId": "",
+                "deviceType": "temperature-sensor",
+                "metric": "temperature",
+                "value": 28.4,
+                "unit": "C",
+                "location": "zone-a"
+              }
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[*].field", hasItems("eventId", "tenantId", "payload.deviceId")))
+                .andExpect(jsonPath("$.errors[*].message", hasItems(
+                        "eventId is required",
+                        "tenantId is required",
+                        "deviceId is required")));
+    }
+
+    @Test
+    @DisplayName("should reject invalid telemetry request when a single nested field is missing")
+    void shouldRejectInvalidTelemetryRequestWhenSingleNestedFieldMissing() throws Exception {
+        String requestBody = """
+            {
+              "eventId": "evt-1001",
+              "tenantId": "factory-01",
+              "eventType": "telemetry.reading",
+              "timestamp": "2026-03-31T12:00:00Z",
+              "source": "sensor-gateway",
+              "version": "1.0",
+              "payload": {
+                "deviceId": "sensor-1042",
+                "metric": "temperature",
+                "value": 28.4,
+                "unit": "C",
+                "location": "zone-a"
+              }
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[*].field", hasItem("payload.deviceType")))
+                .andExpect(jsonPath("$.errors[*].message", hasItem("deviceType is required")));
     }
 
     @Test
@@ -115,7 +205,8 @@ class TelemetryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("source")));
+                .andExpect(jsonPath("$.errors[*].field", hasItem("source")))
+                .andExpect(jsonPath("$.errors[*].message", hasItem("source is required")));
     }
 
     @Test

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -1,17 +1,41 @@
 package com.pulsestream.ingestion.controller;
 
+import com.pulsestream.ingestion.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TelemetryController.class)
+@Import(GlobalExceptionHandler.class)
 class TelemetryControllerTest {
+
+    private static final String VALID_REQUEST_BODY = """
+            {
+              "eventId": "evt-1001",
+              "tenantId": "factory-01",
+              "eventType": "telemetry.reading",
+              "timestamp": "2026-03-31T12:00:00Z",
+              "source": "sensor-gateway",
+              "version": "1.0",
+              "payload": {
+                "deviceId": "sensor-1042",
+                "deviceType": "temperature-sensor",
+                "metric": "temperature",
+                "value": 28.4,
+                "unit": "C",
+                "location": "zone-a"
+              }
+            }
+            """;
 
     @Autowired
     private MockMvc mockMvc;
@@ -40,6 +64,66 @@ class TelemetryControllerTest {
         mockMvc.perform(post("/api/v1/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[*].field", hasItem("eventId")));
+    }
+
+    @Test
+    @DisplayName("should reject invalid telemetry request when timestamp format is invalid")
+    void shouldRejectInvalidTelemetryRequestWhenTimestampFormatInvalid() throws Exception {
+        String requestBody = VALID_REQUEST_BODY.replace(
+                "\"timestamp\": \"2026-03-31T12:00:00Z\"",
+                "\"timestamp\": \"31-03-2026 12:00:00\"");
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Malformed JSON request body or missing required payload."));
+    }
+
+    @Test
+    @DisplayName("should reject invalid telemetry request when payload structure is empty")
+    void shouldRejectInvalidTelemetryRequestWhenPayloadStructureEmpty() throws Exception {
+        String requestBody = """
+            {
+              "eventId": "evt-1001",
+              "tenantId": "factory-01",
+              "eventType": "telemetry.reading",
+              "timestamp": "2026-03-31T12:00:00Z",
+              "source": "sensor-gateway",
+              "version": "1.0",
+              "payload": {}
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[*].field", hasItem("payload.deviceId")));
+    }
+
+    @Test
+    @DisplayName("should reject invalid telemetry request when event metadata is null")
+    void shouldRejectInvalidTelemetryRequestWhenEventMetadataNull() throws Exception {
+        String requestBody = VALID_REQUEST_BODY.replace(
+                "\"source\": \"sensor-gateway\"",
+                "\"source\": null");
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[*].field", hasItem("source")));
+    }
+
+    @Test
+    @DisplayName("should accept valid telemetry request")
+    void shouldAcceptValidTelemetryRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_REQUEST_BODY))
+                .andExpect(status().isAccepted());
     }
 }


### PR DESCRIPTION
## Summary
Enable request validation on the ingestion endpoint so invalid telemetry requests are rejected before entering the processing pipeline.

## Related Issue
Closes #68 

## Issue Requirements Covered
- Reject requests with missing required fields
- Reject requests with invalid timestamp formats, empty payload structures, and null event metadata
- Ensure valid requests continue through the API flow and validation behavior is testable

## Changes
- Enabled controller validation on the telemetry ingestion endpoint
- Applied explicit validation annotations and messages to the ingestion request and payload DTOs
- Added controller tests for invalid payloads returning `400 Bad Request`
- Added controller test coverage for valid payloads continuing with `202 Accepted`
- Ignored the local service `.m2/` cache so generated files do not appear in the PR

## Testing
Ran `mvn test` in `services/ingestion-service`.

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope

## Summary by Sourcery

Enforce validation on telemetry ingestion requests so invalid event payloads are rejected with structured error responses while valid events are accepted.

New Features:
- Introduce explicit validation messages for telemetry ingestion request and payload DTO fields using shared constants.
- Add JSON-based error response handling for telemetry controller validation failures via the global exception handler.

Enhancements:
- Centralize validation message strings into a dedicated ValidationMessages class for reuse across DTOs.

Tests:
- Expand telemetry controller WebMvc tests to cover various invalid request scenarios and confirm valid requests receive 202 Accepted.

Chores:
- Ignore local Maven .m2 cache in the ingestion service module.