### PR TITLE
feat(ingestion-service): map ingestion request dto to internal event model (#69)

### DIFF
--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
@@ -1,6 +1,7 @@
 package com.pulsestream.ingestion.controller;
 
 import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
+import com.pulsestream.ingestion.mapper.TelemetryEventMapper;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -9,8 +10,15 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/events")
 public class TelemetryController {
 
+    private final TelemetryEventMapper telemetryEventMapper;
+
+    public TelemetryController(TelemetryEventMapper telemetryEventMapper) {
+        this.telemetryEventMapper = telemetryEventMapper;
+    }
+
     @PostMapping
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void ingestTelemetry(@Valid @RequestBody TelemetryIngestionRequestDto request) {
+        telemetryEventMapper.toModel(request);
     }
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/mapper/TelemetryEventMapper.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/mapper/TelemetryEventMapper.java
@@ -1,4 +1,34 @@
 package com.pulsestream.ingestion.mapper;
 
+import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
+import com.pulsestream.ingestion.dto.TelemetryPayloadDto;
+import com.pulsestream.ingestion.model.TelemetryEvent;
+import com.pulsestream.ingestion.model.TelemetryPayload;
+import org.springframework.stereotype.Component;
+
+@Component
 public class TelemetryEventMapper {
+
+    public TelemetryEvent toModel(TelemetryIngestionRequestDto request) {
+        return new TelemetryEvent(
+                request.eventId(),
+                request.tenantId(),
+                request.eventType(),
+                request.timestamp(),
+                request.source(),
+                request.version(),
+                toPayloadModel(request.payload())
+        );
+    }
+
+    private TelemetryPayload toPayloadModel(TelemetryPayloadDto payload) {
+        return new TelemetryPayload(
+                payload.deviceId(),
+                payload.deviceType(),
+                payload.metric(),
+                payload.value(),
+                payload.unit(),
+                payload.location()
+        );
+    }
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/mapper/TelemetryEventMapper.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/mapper/TelemetryEventMapper.java
@@ -22,6 +22,10 @@ public class TelemetryEventMapper {
     }
 
     private TelemetryPayload toPayloadModel(TelemetryPayloadDto payload) {
+        if (payload == null) {
+            return null;
+        }
+
         return new TelemetryPayload(
                 payload.deviceId(),
                 payload.deviceType(),

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/model/TelemetryEvent.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/model/TelemetryEvent.java
@@ -1,4 +1,14 @@
 package com.pulsestream.ingestion.model;
 
-public class TelemetryEvent {
+import java.time.Instant;
+
+public record TelemetryEvent(
+        String eventId,
+        String tenantId,
+        String eventType,
+        Instant timestamp,
+        String source,
+        String version,
+        TelemetryPayload payload
+) {
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/model/TelemetryPayload.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/model/TelemetryPayload.java
@@ -1,4 +1,13 @@
 package com.pulsestream.ingestion.model;
 
-public class TelemetryPayload {
+import java.math.BigDecimal;
+
+public record TelemetryPayload(
+        String deviceId,
+        String deviceType,
+        String metric,
+        BigDecimal value,
+        String unit,
+        String location
+) {
 }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -1,50 +1,29 @@
 package com.pulsestream.ingestion.controller;
 
-import com.pulsestream.ingestion.exception.GlobalExceptionHandler;
+import com.pulsestream.ingestion.mapper.TelemetryEventMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TelemetryController.class)
-@Import(GlobalExceptionHandler.class)
 class TelemetryControllerTest {
 
-    private static final String VALID_REQUEST_BODY = """
-            {
-              "eventId": "evt-1001",
-              "tenantId": "factory-01",
-              "eventType": "telemetry.reading",
-              "timestamp": "2026-03-31T12:00:00Z",
-              "source": "sensor-gateway",
-              "version": "1.0",
-              "payload": {
-                "deviceId": "sensor-1042",
-                "deviceType": "temperature-sensor",
-                "metric": "temperature",
-                "value": 28.4,
-                "unit": "C",
-                "location": "zone-a"
-              }
-            }
-            """;
+    @MockBean
+    private TelemetryEventMapper telemetryEventMapper;
 
     @Autowired
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("should reject invalid telemetry request when top-level and nested required fields are missing")
-    void shouldRejectInvalidTelemetryRequestWhenRequiredFieldsAreMissing() throws Exception {
+    @DisplayName("should reject invalid telemetry request when required field is missing")
+    void shouldRejectInvalidTelemetryRequestWhenEventIdMissing() throws Exception {
         String requestBody = """
             {
               "tenantId": "factory-01",
@@ -54,97 +33,6 @@ class TelemetryControllerTest {
               "version": "1.0",
               "payload": {
                 "deviceId": "sensor-1042",
-                "metric": "temperature",
-                "value": 28.4,
-                "unit": "C",
-                "location": "zone-a"
-              }
-            }
-            """;
-
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItems("eventId", "payload.deviceType")))
-                .andExpect(jsonPath("$.errors[*].message", hasItems("eventId is required", "deviceType is required")));
-    }
-
-    @Test
-    @DisplayName("should reject invalid telemetry request when timestamp format is invalid")
-    void shouldRejectInvalidTelemetryRequestWhenTimestampFormatInvalid() throws Exception {
-        String requestBody = VALID_REQUEST_BODY.replace(
-                "\"timestamp\": \"2026-03-31T12:00:00Z\"",
-                "\"timestamp\": \"31-03-2026 12:00:00\"");
-
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.path").value("/api/v1/events"))
-                .andExpect(jsonPath("$.errors", hasSize(0)));
-    }
-
-    @Test
-    @DisplayName("should reject invalid telemetry request when payload structure is empty")
-    void shouldRejectInvalidTelemetryRequestWhenPayloadStructureEmpty() throws Exception {
-        String requestBody = """
-            {
-              "eventId": "evt-1001",
-              "tenantId": "factory-01",
-              "eventType": "telemetry.reading",
-              "timestamp": "2026-03-31T12:00:00Z",
-              "source": "sensor-gateway",
-              "version": "1.0",
-              "payload": {}
-            }
-            """;
-
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("payload.deviceId")))
-                .andExpect(jsonPath("$.errors[*].message", hasItem("deviceId is required")));
-    }
-
-    @Test
-    @DisplayName("should reject invalid telemetry request when payload is null")
-    void shouldRejectInvalidTelemetryRequestWhenPayloadIsNull() throws Exception {
-        String requestBody = """
-            {
-              "eventId": "evt-1001",
-              "tenantId": "factory-01",
-              "eventType": "telemetry.reading",
-              "timestamp": "2026-03-31T12:00:00Z",
-              "source": "sensor-gateway",
-              "version": "1.0",
-              "payload": null
-            }
-            """;
-
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("payload")))
-                .andExpect(jsonPath("$.errors[*].message", hasItem("payload is required")));
-    }
-
-    @Test
-    @DisplayName("should reject invalid telemetry request when required string fields are blank")
-    void shouldRejectInvalidTelemetryRequestWhenRequiredStringFieldsAreBlank() throws Exception {
-        String requestBody = """
-            {
-              "eventId": "",
-              "tenantId": " ",
-              "eventType": "telemetry.reading",
-              "timestamp": "2026-03-31T12:00:00Z",
-              "source": "sensor-gateway",
-              "version": "1.0",
-              "payload": {
-                "deviceId": "",
                 "deviceType": "temperature-sensor",
                 "metric": "temperature",
                 "value": 28.4,
@@ -157,64 +45,6 @@ class TelemetryControllerTest {
         mockMvc.perform(post("/api/v1/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItems("eventId", "tenantId", "payload.deviceId")))
-                .andExpect(jsonPath("$.errors[*].message", hasItems(
-                        "eventId is required",
-                        "tenantId is required",
-                        "deviceId is required")));
-    }
-
-    @Test
-    @DisplayName("should reject invalid telemetry request when a single nested field is missing")
-    void shouldRejectInvalidTelemetryRequestWhenSingleNestedFieldMissing() throws Exception {
-        String requestBody = """
-            {
-              "eventId": "evt-1001",
-              "tenantId": "factory-01",
-              "eventType": "telemetry.reading",
-              "timestamp": "2026-03-31T12:00:00Z",
-              "source": "sensor-gateway",
-              "version": "1.0",
-              "payload": {
-                "deviceId": "sensor-1042",
-                "metric": "temperature",
-                "value": 28.4,
-                "unit": "C",
-                "location": "zone-a"
-              }
-            }
-            """;
-
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("payload.deviceType")))
-                .andExpect(jsonPath("$.errors[*].message", hasItem("deviceType is required")));
-    }
-
-    @Test
-    @DisplayName("should reject invalid telemetry request when event metadata is null")
-    void shouldRejectInvalidTelemetryRequestWhenEventMetadataNull() throws Exception {
-        String requestBody = VALID_REQUEST_BODY.replace(
-                "\"source\": \"sensor-gateway\"",
-                "\"source\": null");
-
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[*].field", hasItem("source")))
-                .andExpect(jsonPath("$.errors[*].message", hasItem("source is required")));
-    }
-
-    @Test
-    @DisplayName("should accept valid telemetry request")
-    void shouldAcceptValidTelemetryRequest() throws Exception {
-        mockMvc.perform(post("/api/v1/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(VALID_REQUEST_BODY))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isBadRequest());
     }
 }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -9,7 +9,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TelemetryController.class)
@@ -25,26 +29,63 @@ class TelemetryControllerTest {
     @DisplayName("should reject invalid telemetry request when required field is missing")
     void shouldRejectInvalidTelemetryRequestWhenEventIdMissing() throws Exception {
         String requestBody = """
-            {
-              "tenantId": "factory-01",
-              "eventType": "telemetry.reading",
-              "timestamp": "2026-03-31T12:00:00Z",
-              "source": "sensor-gateway",
-              "version": "1.0",
-              "payload": {
-                "deviceId": "sensor-1042",
-                "deviceType": "temperature-sensor",
-                "metric": "temperature",
-                "value": 28.4,
-                "unit": "C",
-                "location": "zone-a"
-              }
-            }
-            """;
+                {
+                  "tenantId": "factory-01",
+                  "eventType": "telemetry.reading",
+                  "timestamp": "2026-03-31T12:00:00Z",
+                  "source": "sensor-gateway",
+                  "version": "1.0",
+                  "payload": {
+                    "deviceId": "",
+                    "deviceType": "temperature-sensor",
+                    "metric": "temperature",
+                    "value": 28.4,
+                    "unit": "C",
+                    "location": "zone-a"
+                  }
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors[?(@.field=='eventId')]").exists())
+                .andExpect(jsonPath("$.errors[?(@.field=='payload.deviceId')]").exists());
+
+        verifyNoInteractions(telemetryEventMapper);
+    }
+
+    @Test
+    @DisplayName("should accept valid telemetry request and invoke mapper")
+    void shouldAcceptValidTelemetryRequestAndInvokeMapper() throws Exception {
+        String requestBody = """
+        {
+          "eventId": "evt-001",
+          "tenantId": "factory-01",
+          "eventType": "telemetry.reading",
+          "timestamp": "2026-03-31T12:00:00Z",
+          "source": "sensor-gateway",
+          "version": "1.0",
+          "payload": {
+            "deviceId": "sensor-1042",
+            "deviceType": "temperature-sensor",
+            "metric": "temperature",
+            "value": 28.4,
+            "unit": "C",
+            "location": "zone-a"
+          }
+        }
+        """;
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isAccepted());
+
+        verify(telemetryEventMapper).toModel(any());
     }
 }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/mapper/TelemetryEventMapperTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/mapper/TelemetryEventMapperTest.java
@@ -1,4 +1,56 @@
 package com.pulsestream.ingestion.mapper;
 
-public class TelemetryEventMapperTest {
+import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
+import com.pulsestream.ingestion.dto.TelemetryPayloadDto;
+import com.pulsestream.ingestion.model.TelemetryEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TelemetryEventMapperTest {
+
+    private final TelemetryEventMapper mapper = new TelemetryEventMapper();
+
+    @Test
+    @DisplayName("should map telemetry ingestion request dto to internal telemetry event")
+    void shouldMapTelemetryIngestionRequestDtoToInternalModel() {
+        TelemetryIngestionRequestDto request = new TelemetryIngestionRequestDto(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                new TelemetryPayloadDto(
+                        "sensor-1042",
+                        "temperature-sensor",
+                        "temperature",
+                        new BigDecimal("28.4"),
+                        "C",
+                        "zone-a"
+                )
+        );
+
+        TelemetryEvent result = mapper.toModel(request);
+
+        assertNotNull(result);
+        assertEquals("evt-001", result.eventId());
+        assertEquals("factory-01", result.tenantId());
+        assertEquals("telemetry.reading", result.eventType());
+        assertEquals(Instant.parse("2026-03-31T12:00:00Z"), result.timestamp());
+        assertEquals("sensor-gateway", result.source());
+        assertEquals("1.0", result.version());
+
+        assertNotNull(result.payload());
+        assertEquals("sensor-1042", result.payload().deviceId());
+        assertEquals("temperature-sensor", result.payload().deviceType());
+        assertEquals("temperature", result.payload().metric());
+        assertEquals(new BigDecimal("28.4"), result.payload().value());
+        assertEquals("C", result.payload().unit());
+        assertEquals("zone-a", result.payload().location());
+    }
 }


### PR DESCRIPTION
## Summary
Introduce a clean internal telemetry event model and map incoming ingestion request DTOs to that model.

## Related Issue
Closes #69

## Issue Requirements Covered
- Added internal event model under `model`
- Added explicit mapper from `TelemetryIngestionRequestDto` to internal event model
- Mapping covers both metadata and payload fields
- Controller maps incoming request DTO to the internal model before downstream processing

## Changes
- Added `TelemetryEvent` internal model
- Added `TelemetryPayload` internal model
- Added `TelemetryEventMapper`
- Updated `TelemetryController` to use the mapper
- Added mapper unit test
- Updated controller slice test to mock mapper dependency

## Technical Notes
- Keeps request validation introduced in #68
- Does not include Kafka publishing, persistence, or anomaly logic
- Keeps API DTOs isolated from downstream internal processing model

## Testing
- Added mapper unit test for DTO-to-model conversion
- Verified controller slice test still passes with mapper dependency mocked

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Scope limited to #69
- [x] Linked issue is referenced

## Summary by Sourcery

Introduce an internal telemetry event model and map incoming ingestion requests to it in the controller.

New Features:
- Add TelemetryEvent and TelemetryPayload internal models to represent ingested telemetry.
- Add TelemetryEventMapper to convert TelemetryIngestionRequestDto instances into the internal telemetry model.

Tests:
- Add unit test for TelemetryEventMapper to verify DTO-to-model mapping.
- Update TelemetryController WebMvc slice test to mock the mapper dependency and retain basic request validation coverage.