### PR TITLE
feat(ingestion-service): serialize telemetry event model for kafka publishing (#74)

### DIFF
--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/model/TelemetryEvent.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/model/TelemetryEvent.java
@@ -1,12 +1,14 @@
 package com.pulsestream.ingestion.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.Instant;
 
 public record TelemetryEvent(
         String eventId,
         String tenantId,
         String eventType,
-        Instant timestamp,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) Instant timestamp,
         String source,
         String version,
         TelemetryPayload payload

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/serialization/TelemetryEventSerializer.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/serialization/TelemetryEventSerializer.java
@@ -1,0 +1,24 @@
+package com.pulsestream.ingestion.serialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pulsestream.ingestion.model.TelemetryEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TelemetryEventSerializer {
+
+    private final ObjectMapper objectMapper;
+
+    public TelemetryEventSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public String serialize(TelemetryEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException ex) {
+            throw new TelemetrySerializationException("Failed to serialize telemetry event", ex);
+        }
+    }
+}

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/serialization/TelemetrySerializationException.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/serialization/TelemetrySerializationException.java
@@ -1,0 +1,8 @@
+package com.pulsestream.ingestion.serialization;
+
+public class TelemetrySerializationException extends RuntimeException {
+
+    public TelemetrySerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/serialization/TelemetryEventSerializerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/serialization/TelemetryEventSerializerTest.java
@@ -1,0 +1,53 @@
+package com.pulsestream.ingestion.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pulsestream.ingestion.model.TelemetryEvent;
+import com.pulsestream.ingestion.model.TelemetryPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TelemetryEventSerializerTest {
+
+    private final TelemetryEventSerializer serializer =
+            new TelemetryEventSerializer(new ObjectMapper().findAndRegisterModules());
+
+    @Test
+    @DisplayName("should serialize telemetry event to json")
+    void shouldSerializeTelemetryEventToJson() {
+        TelemetryEvent event = new TelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                new TelemetryPayload(
+                        "sensor-1042",
+                        "temperature-sensor",
+                        "temperature",
+                        new BigDecimal("28.4"),
+                        "C",
+                        "zone-a"
+                )
+        );
+
+        String json = serializer.serialize(event);
+
+        assertNotNull(json);
+        assertTrue(json.contains("\"eventId\":\"evt-001\""));
+        assertTrue(json.contains("\"tenantId\":\"factory-01\""));
+        assertTrue(json.contains("\"eventType\":\"telemetry.reading\""));
+        assertTrue(json.contains("\"source\":\"sensor-gateway\""));
+        assertTrue(json.contains("\"version\":\"1.0\""));
+        assertTrue(json.contains("\"deviceId\":\"sensor-1042\""));
+        assertTrue(json.contains("\"metric\":\"temperature\""));
+        assertTrue(json.contains("\"value\":28.4"));
+        assertTrue(json.contains("\"unit\":\"C\""));
+        assertTrue(json.contains("\"location\":\"zone-a\""));
+    }
+}

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/serialization/TelemetryEventSerializerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/serialization/TelemetryEventSerializerTest.java
@@ -1,5 +1,7 @@
 package com.pulsestream.ingestion.serialization;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pulsestream.ingestion.model.TelemetryEvent;
 import com.pulsestream.ingestion.model.TelemetryPayload;
@@ -10,15 +12,19 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class TelemetryEventSerializerTest {
 
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     private final TelemetryEventSerializer serializer =
-            new TelemetryEventSerializer(new ObjectMapper().findAndRegisterModules());
+            new TelemetryEventSerializer(objectMapper);
 
     @Test
     @DisplayName("should serialize telemetry event to json")
-    void shouldSerializeTelemetryEventToJson() {
+    void shouldSerializeTelemetryEventToJson() throws JsonProcessingException {
         TelemetryEvent event = new TelemetryEvent(
                 "evt-001",
                 "factory-01",
@@ -39,15 +45,53 @@ class TelemetryEventSerializerTest {
         String json = serializer.serialize(event);
 
         assertNotNull(json);
-        assertTrue(json.contains("\"eventId\":\"evt-001\""));
-        assertTrue(json.contains("\"tenantId\":\"factory-01\""));
-        assertTrue(json.contains("\"eventType\":\"telemetry.reading\""));
-        assertTrue(json.contains("\"source\":\"sensor-gateway\""));
-        assertTrue(json.contains("\"version\":\"1.0\""));
-        assertTrue(json.contains("\"deviceId\":\"sensor-1042\""));
-        assertTrue(json.contains("\"metric\":\"temperature\""));
-        assertTrue(json.contains("\"value\":28.4"));
-        assertTrue(json.contains("\"unit\":\"C\""));
-        assertTrue(json.contains("\"location\":\"zone-a\""));
+
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("evt-001", root.get("eventId").asText());
+        assertEquals("factory-01", root.get("tenantId").asText());
+        assertEquals("telemetry.reading", root.get("eventType").asText());
+        assertEquals("sensor-gateway", root.get("source").asText());
+        assertEquals("1.0", root.get("version").asText());
+        assertEquals("2026-03-31T12:00:00Z", root.get("timestamp").asText());
+
+        JsonNode payload = root.get("payload");
+        assertEquals("sensor-1042", payload.get("deviceId").asText());
+        assertEquals("temperature-sensor", payload.get("deviceType").asText());
+        assertEquals("temperature", payload.get("metric").asText());
+        assertEquals(new BigDecimal("28.4"), payload.get("value").decimalValue());
+        assertEquals("C", payload.get("unit").asText());
+        assertEquals("zone-a", payload.get("location").asText());
+    }
+
+    @Test
+    @DisplayName("should wrap serialization exceptions")
+    void shouldWrapSerializationException() throws Exception {
+        ObjectMapper failingMapper = mock(ObjectMapper.class);
+
+        JsonProcessingException rootCause = new JsonProcessingException("fail") {};
+        when(failingMapper.writeValueAsString(any()))
+                .thenThrow(rootCause);
+
+        TelemetryEventSerializer serializer =
+                new TelemetryEventSerializer(failingMapper);
+
+        TelemetryEvent event = new TelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.now(),
+                "sensor-gateway",
+                "1.0",
+                null
+        );
+
+        TelemetrySerializationException ex = assertThrows(
+                TelemetrySerializationException.class,
+                () -> serializer.serialize(event)
+        );
+
+        assertEquals("Failed to serialize telemetry event", ex.getMessage());
+        assertSame(rootCause, ex.getCause());
     }
 }


### PR DESCRIPTION
## Summary
Implement JSON serialization for the internal telemetry event model prior to Kafka publishing.

## Related Issue
Closes #74

## Issue Requirements Covered
- Implemented event serialization strategy
- JSON output aligns with the internal telemetry event structure
- Metadata and payload fields are preserved during serialization

## Changes
- Added `TelemetryEventSerializer`
- Added `TelemetrySerializationException`
- Added unit test for telemetry event JSON serialization

## Technical Notes
- This PR focuses only on model-to-JSON serialization
- Kafka publishing logic is intentionally excluded
- No Avro, Protobuf, or schema registry integration included

## Testing
- Added unit test to verify serialized output contains expected metadata and payload fields

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Scope limited to #74
- [x] Linked issue is referenced

## Summary by Sourcery

Add JSON serialization support for telemetry events in the ingestion service for downstream Kafka publishing.

New Features:
- Introduce a TelemetryEventSerializer component to convert TelemetryEvent instances to JSON strings.
- Add a custom TelemetrySerializationException for handling serialization failures.

Tests:
- Add unit test verifying telemetry events are serialized to JSON with expected metadata and payload fields.