### PR TITLE
feat(ingestion-service): publish telemetry events to raw Kafka topic (#75)

### DIFF
--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/controller/TelemetryController.java
@@ -2,6 +2,8 @@ package com.pulsestream.ingestion.controller;
 
 import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
 import com.pulsestream.ingestion.mapper.TelemetryEventMapper;
+import com.pulsestream.ingestion.model.TelemetryEvent;
+import com.pulsestream.ingestion.service.KafkaProducerService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -11,14 +13,21 @@ import org.springframework.web.bind.annotation.*;
 public class TelemetryController {
 
     private final TelemetryEventMapper telemetryEventMapper;
+    private final KafkaProducerService kafkaProducerService;
 
-    public TelemetryController(TelemetryEventMapper telemetryEventMapper) {
+    public TelemetryController(
+            TelemetryEventMapper telemetryEventMapper,
+            KafkaProducerService kafkaProducerService
+    ) {
         this.telemetryEventMapper = telemetryEventMapper;
+        this.kafkaProducerService = kafkaProducerService;
     }
+
 
     @PostMapping
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void ingestTelemetry(@Valid @RequestBody TelemetryIngestionRequestDto request) {
-        telemetryEventMapper.toModel(request);
+        TelemetryEvent telemetryEvent = telemetryEventMapper.toModel(request);
+        kafkaProducerService.publishTelemetryEvent(telemetryEvent);
     }
 }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -1,6 +1,9 @@
 package com.pulsestream.ingestion.controller;
 
+import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
 import com.pulsestream.ingestion.mapper.TelemetryEventMapper;
+import com.pulsestream.ingestion.model.TelemetryEvent;
+import com.pulsestream.ingestion.service.KafkaProducerService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,10 +11,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.mockito.Mockito.when;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,6 +25,9 @@ class TelemetryControllerTest {
 
     @MockBean
     private TelemetryEventMapper telemetryEventMapper;
+
+    @MockBean
+    private KafkaProducerService kafkaProducerService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -56,6 +63,7 @@ class TelemetryControllerTest {
                 .andExpect(jsonPath("$.errors[?(@.field=='payload.deviceId')]").exists());
 
         verifyNoInteractions(telemetryEventMapper);
+        verifyNoInteractions(kafkaProducerService);
     }
 
     @Test
@@ -80,11 +88,16 @@ class TelemetryControllerTest {
         }
         """;
 
+        when(telemetryEventMapper.toModel(any(TelemetryIngestionRequestDto.class)))
+                .thenReturn(mock(TelemetryEvent.class));
+
         mockMvc.perform(post("/api/v1/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isAccepted());
 
-        verify(telemetryEventMapper).toModel(any());
+
+        verify(telemetryEventMapper).toModel(any(TelemetryIngestionRequestDto.class));
+        verify(kafkaProducerService).publishTelemetryEvent(any(TelemetryEvent.class));;
     }
 }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -98,6 +98,6 @@ class TelemetryControllerTest {
 
 
         verify(telemetryEventMapper).toModel(any(TelemetryIngestionRequestDto.class));
-        verify(kafkaProducerService).publishTelemetryEvent(any(TelemetryEvent.class));;
+        verify(kafkaProducerService).publishTelemetryEvent(any(TelemetryEvent.class));
     }
 }


### PR DESCRIPTION
## Summary
Integrate the Kafka producer into the ingestion flow to publish validated telemetry events to the ``telemetry.events.raw`` topic.

## Related Issue
Closes #75 

## Issue Requirements Covered
- Publish valid telemetry events to telemetry.events.raw
- Use configured topic from PulsestreamKafkaProperties
- Trigger publishing only after successful validation and mapping

## Changes
- Updated TelemetryController to invoke KafkaProducerService after mapping request → domain event
- Integrated KafkaProducerService.publishTelemetryEvent(...) into ingestion flow
- Fixed endpoint mapping to ensure correct request routing (/api/v1/events)
- Updated controller tests to verify Kafka publishing is triggered for valid requests and not for invalid ones

## Testing
- Added/updated TelemetryControllerTest:
   - Valid request → returns 202 Accepted and triggers Kafka publish
   - Invalid request → returns 400 Bad Request and does not invoke mapper or producer
- Ran full test suite:
   - All unit and integration tests passing (mvn test)

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [ ] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope

## Summary by Sourcery

Integrate Kafka publishing into the telemetry ingestion flow after successful request validation and mapping.

New Features:
- Publish mapped telemetry events to Kafka via KafkaProducerService from the ingestion controller.

Tests:
- Extend TelemetryController tests to cover Kafka producer interactions for valid and invalid telemetry requests.