### PR TITLE
Handle Kafka publish failures in ingestion service

### DIFF
--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/config/PulsestreamKafkaProperties.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/config/PulsestreamKafkaProperties.java
@@ -47,6 +47,8 @@ public class PulsestreamKafkaProperties {
 
         private Duration deliveryTimeout = Duration.ofSeconds(30);
 
+        private Duration publishTimeout = Duration.ofSeconds(5);
+
         private Map<String, String> properties = new LinkedHashMap<>();
 
         public String getClientId() {
@@ -95,6 +97,14 @@ public class PulsestreamKafkaProperties {
 
         public void setDeliveryTimeout(Duration deliveryTimeout) {
             this.deliveryTimeout = deliveryTimeout;
+        }
+
+        public Duration getPublishTimeout() {
+            return publishTimeout;
+        }
+
+        public void setPublishTimeout(Duration publishTimeout) {
+            this.publishTimeout = publishTimeout;
         }
 
         public Map<String, String> getProperties() {

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/exception/GlobalExceptionHandler.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/exception/GlobalExceptionHandler.java
@@ -70,6 +70,26 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handles Kafka publishing failures after request validation has succeeded.
+     */
+    @ExceptionHandler(TelemetryPublishingException.class)
+    public ResponseEntity<ErrorResponse> handleTelemetryPublishingException(
+            TelemetryPublishingException ex, HttpServletRequest request) {
+
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.SERVICE_UNAVAILABLE.value(),
+                "Service Unavailable",
+                "Telemetry event could not be accepted because publishing is currently unavailable.",
+                request.getRequestURI(),
+                List.of()
+        );
+
+        log.warn("Kafka publishing failure while processing request to {}", request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
+    }
+
+    /**
      * Catch-all handler for any other unhandled exceptions.
      */
     @ExceptionHandler(Exception.class)

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/exception/GlobalExceptionHandler.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/exception/GlobalExceptionHandler.java
@@ -85,7 +85,7 @@ public class GlobalExceptionHandler {
                 List.of()
         );
 
-        log.warn("Kafka publishing failure while processing request to {}", request.getRequestURI());
+        log.warn("Kafka publishing failure while processing request to {}", request.getRequestURI(), ex);
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
     }
 

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/exception/TelemetryPublishingException.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/exception/TelemetryPublishingException.java
@@ -1,0 +1,8 @@
+package com.pulsestream.ingestion.exception;
+
+public class TelemetryPublishingException extends RuntimeException {
+
+    public TelemetryPublishingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/service/KafkaProducerService.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/service/KafkaProducerService.java
@@ -1,17 +1,21 @@
 package com.pulsestream.ingestion.service;
 
 import com.pulsestream.ingestion.config.PulsestreamKafkaProperties;
+import com.pulsestream.ingestion.exception.TelemetryPublishingException;
 import com.pulsestream.ingestion.model.TelemetryEvent;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 @Service
 public class KafkaProducerService {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaProducerService.class);
 
     private final KafkaTemplate<String, TelemetryEvent> telemetryKafkaTemplate;
 
@@ -25,14 +29,19 @@ public class KafkaProducerService {
         this.kafkaProperties = kafkaProperties;
     }
 
-    public CompletableFuture<SendResult<String, TelemetryEvent>> publishTelemetryEvent(TelemetryEvent telemetryEvent) {
+    public void publishTelemetryEvent(TelemetryEvent telemetryEvent) {
         Assert.notNull(telemetryEvent, "telemetryEvent must not be null");
 
-        return telemetryKafkaTemplate.send(
-                kafkaProperties.getTopics().getRaw(),
-                resolveMessageKey(telemetryEvent),
-                telemetryEvent
-        );
+        String topic = kafkaProperties.getTopics().getRaw();
+        String messageKey = resolveMessageKey(telemetryEvent);
+
+        try {
+            telemetryKafkaTemplate.send(topic, messageKey, telemetryEvent).join();
+        } catch (CompletionException ex) {
+            throw publishFailure(telemetryEvent, topic, messageKey, ex.getCause() != null ? ex.getCause() : ex);
+        } catch (RuntimeException ex) {
+            throw publishFailure(telemetryEvent, topic, messageKey, ex);
+        }
     }
 
     private String resolveMessageKey(TelemetryEvent telemetryEvent) {
@@ -44,5 +53,21 @@ public class KafkaProducerService {
                 "telemetryEvent must contain a non-blank tenantId when eventId is blank");
 
         return telemetryEvent.tenantId().trim();
+    }
+
+    private TelemetryPublishingException publishFailure(
+            TelemetryEvent telemetryEvent,
+            String topic,
+            String messageKey,
+            Throwable cause
+    ) {
+        log.error(
+                "Failed to publish telemetry event to Kafka topic={} key={} eventId={}",
+                topic,
+                messageKey,
+                telemetryEvent.eventId(),
+                cause
+        );
+        return new TelemetryPublishingException("Failed to publish telemetry event to Kafka", cause);
     }
 }

--- a/services/ingestion-service/src/main/java/com/pulsestream/ingestion/service/KafkaProducerService.java
+++ b/services/ingestion-service/src/main/java/com/pulsestream/ingestion/service/KafkaProducerService.java
@@ -3,7 +3,10 @@ package com.pulsestream.ingestion.service;
 import com.pulsestream.ingestion.config.PulsestreamKafkaProperties;
 import com.pulsestream.ingestion.exception.TelemetryPublishingException;
 import com.pulsestream.ingestion.model.TelemetryEvent;
-import java.util.concurrent.CompletionException;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,11 +37,21 @@ public class KafkaProducerService {
 
         String topic = kafkaProperties.getTopics().getRaw();
         String messageKey = resolveMessageKey(telemetryEvent);
+        long publishTimeoutMillis = publishTimeoutMillis();
 
         try {
-            telemetryKafkaTemplate.send(topic, messageKey, telemetryEvent).join();
-        } catch (CompletionException ex) {
+            telemetryKafkaTemplate.send(topic, messageKey, telemetryEvent)
+                    .get(publishTimeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw publishFailure(telemetryEvent, topic, messageKey, ex);
+        } catch (ExecutionException ex) {
             throw publishFailure(telemetryEvent, topic, messageKey, ex.getCause() != null ? ex.getCause() : ex);
+        } catch (TimeoutException ex) {
+            TimeoutException timeoutException =
+                    new TimeoutException("Kafka publish did not complete within " + publishTimeoutMillis + " ms");
+            timeoutException.initCause(ex);
+            throw publishFailure(telemetryEvent, topic, messageKey, timeoutException);
         } catch (RuntimeException ex) {
             throw publishFailure(telemetryEvent, topic, messageKey, ex);
         }
@@ -53,6 +66,14 @@ public class KafkaProducerService {
                 "telemetryEvent must contain a non-blank tenantId when eventId is blank");
 
         return telemetryEvent.tenantId().trim();
+    }
+
+    private long publishTimeoutMillis() {
+        Duration publishTimeout = kafkaProperties.getProducer().getPublishTimeout();
+        Assert.notNull(publishTimeout, "Kafka producer publish timeout must not be null");
+        Assert.isTrue(publishTimeout.toMillis() > 0,
+                "Kafka producer publish timeout must be greater than zero");
+        return publishTimeout.toMillis();
     }
 
     private TelemetryPublishingException publishFailure(

--- a/services/ingestion-service/src/main/resources/application.yml
+++ b/services/ingestion-service/src/main/resources/application.yml
@@ -29,6 +29,7 @@ pulsestream:
       acknowledgements: ${PULSESTREAM_KAFKA_PRODUCER_ACKNOWLEDGEMENTS:all}
       retries: ${PULSESTREAM_KAFKA_PRODUCER_RETRIES:3}
       delivery-timeout: ${PULSESTREAM_KAFKA_PRODUCER_DELIVERY_TIMEOUT:30s}
+      publish-timeout: ${PULSESTREAM_KAFKA_PRODUCER_PUBLISH_TIMEOUT:5s}
       properties: {}
     topics:
       raw: telemetry.events.raw

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/controller/TelemetryControllerTest.java
@@ -1,6 +1,7 @@
 package com.pulsestream.ingestion.controller;
 
 import com.pulsestream.ingestion.dto.TelemetryIngestionRequestDto;
+import com.pulsestream.ingestion.exception.TelemetryPublishingException;
 import com.pulsestream.ingestion.mapper.TelemetryEventMapper;
 import com.pulsestream.ingestion.model.TelemetryEvent;
 import com.pulsestream.ingestion.service.KafkaProducerService;
@@ -99,5 +100,48 @@ class TelemetryControllerTest {
 
         verify(telemetryEventMapper).toModel(any(TelemetryIngestionRequestDto.class));
         verify(kafkaProducerService).publishTelemetryEvent(any(TelemetryEvent.class));
+    }
+
+    @Test
+    @DisplayName("should return controlled response when Kafka publishing fails")
+    void shouldReturnControlledResponseWhenKafkaPublishingFails() throws Exception {
+        String requestBody = """
+        {
+          "eventId": "evt-001",
+          "tenantId": "factory-01",
+          "eventType": "telemetry.reading",
+          "timestamp": "2026-03-31T12:00:00Z",
+          "source": "sensor-gateway",
+          "version": "1.0",
+          "payload": {
+            "deviceId": "sensor-1042",
+            "deviceType": "temperature-sensor",
+            "metric": "temperature",
+            "value": 28.4,
+            "unit": "C",
+            "location": "zone-a"
+          }
+        }
+        """;
+
+        TelemetryEvent telemetryEvent = mock(TelemetryEvent.class);
+        when(telemetryEventMapper.toModel(any(TelemetryIngestionRequestDto.class)))
+                .thenReturn(telemetryEvent);
+        doThrow(new TelemetryPublishingException(
+                "Failed to publish telemetry event to Kafka",
+                new RuntimeException("broker unavailable")
+        )).when(kafkaProducerService).publishTelemetryEvent(telemetryEvent);
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.status").value(503))
+                .andExpect(jsonPath("$.error").value("Service Unavailable"))
+                .andExpect(jsonPath("$.message")
+                        .value("Telemetry event could not be accepted because publishing is currently unavailable."));
+
+        verify(telemetryEventMapper).toModel(any(TelemetryIngestionRequestDto.class));
+        verify(kafkaProducerService).publishTelemetryEvent(telemetryEvent);
     }
 }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/service/KafkaProducerServiceTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/service/KafkaProducerServiceTest.java
@@ -5,8 +5,10 @@ import com.pulsestream.ingestion.exception.TelemetryPublishingException;
 import com.pulsestream.ingestion.model.TelemetryEvent;
 import com.pulsestream.ingestion.model.TelemetryPayload;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.DisplayName;
@@ -94,6 +96,24 @@ class KafkaProducerServiceTest {
                 .isInstanceOf(TelemetryPublishingException.class)
                 .hasMessage("Failed to publish telemetry event to Kafka")
                 .hasCause(kafkaException);
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should throw controlled exception when Kafka send does not complete before timeout")
+    void shouldThrowControlledExceptionWhenKafkaSendDoesNotCompleteBeforeTimeout() {
+        kafkaProperties.getProducer().setPublishTimeout(Duration.ofMillis(10));
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        CompletableFuture<SendResult<String, TelemetryEvent>> sendFuture = new CompletableFuture<>();
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent))
+                .thenReturn(sendFuture);
+
+        assertThatThrownBy(() -> kafkaProducerService.publishTelemetryEvent(telemetryEvent))
+                .isInstanceOf(TelemetryPublishingException.class)
+                .hasMessage("Failed to publish telemetry event to Kafka")
+                .hasCauseInstanceOf(TimeoutException.class);
 
         verify(kafkaTemplate).send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent);
     }

--- a/services/ingestion-service/src/test/java/com/pulsestream/ingestion/service/KafkaProducerServiceTest.java
+++ b/services/ingestion-service/src/test/java/com/pulsestream/ingestion/service/KafkaProducerServiceTest.java
@@ -1,18 +1,20 @@
 package com.pulsestream.ingestion.service;
 
 import com.pulsestream.ingestion.config.PulsestreamKafkaProperties;
+import com.pulsestream.ingestion.exception.TelemetryPublishingException;
 import com.pulsestream.ingestion.model.TelemetryEvent;
 import com.pulsestream.ingestion.model.TelemetryPayload;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -33,14 +35,14 @@ class KafkaProducerServiceTest {
     void shouldPublishTelemetryEventsToTheConfiguredRawTopic() {
         TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
         CompletableFuture<SendResult<String, TelemetryEvent>> sendFuture = new CompletableFuture<>();
+        sendFuture.complete(sendResult());
 
         when(kafkaTemplate.send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent))
                 .thenReturn(sendFuture);
 
-        CompletableFuture<SendResult<String, TelemetryEvent>> result =
-                kafkaProducerService.publishTelemetryEvent(telemetryEvent);
+        assertThatCode(() -> kafkaProducerService.publishTelemetryEvent(telemetryEvent))
+                .doesNotThrowAnyException();
 
-        assertThat(result).isSameAs(sendFuture);
         verify(kafkaTemplate).send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent);
     }
 
@@ -49,15 +51,51 @@ class KafkaProducerServiceTest {
     void shouldFallBackToTenantIdWhenEventIdIsBlank() {
         TelemetryEvent telemetryEvent = telemetryEvent(" ", "factory-01");
         CompletableFuture<SendResult<String, TelemetryEvent>> sendFuture = new CompletableFuture<>();
+        sendFuture.complete(sendResult());
 
         when(kafkaTemplate.send(kafkaProperties.getTopics().getRaw(), "factory-01", telemetryEvent))
                 .thenReturn(sendFuture);
 
-        CompletableFuture<SendResult<String, TelemetryEvent>> result =
-                kafkaProducerService.publishTelemetryEvent(telemetryEvent);
+        assertThatCode(() -> kafkaProducerService.publishTelemetryEvent(telemetryEvent))
+                .doesNotThrowAnyException();
 
-        assertThat(result).isSameAs(sendFuture);
         verify(kafkaTemplate).send(kafkaProperties.getTopics().getRaw(), "factory-01", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should throw controlled exception when Kafka send completes with failure")
+    void shouldThrowControlledExceptionWhenKafkaSendCompletesWithFailure() {
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        CompletableFuture<SendResult<String, TelemetryEvent>> sendFuture = new CompletableFuture<>();
+        KafkaException kafkaException = new KafkaException("broker unavailable");
+        sendFuture.completeExceptionally(kafkaException);
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent))
+                .thenReturn(sendFuture);
+
+        assertThatThrownBy(() -> kafkaProducerService.publishTelemetryEvent(telemetryEvent))
+                .isInstanceOf(TelemetryPublishingException.class)
+                .hasMessage("Failed to publish telemetry event to Kafka")
+                .hasCause(kafkaException);
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should throw controlled exception when Kafka send fails immediately")
+    void shouldThrowControlledExceptionWhenKafkaSendFailsImmediately() {
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        KafkaException kafkaException = new KafkaException("producer unavailable");
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent))
+                .thenThrow(kafkaException);
+
+        assertThatThrownBy(() -> kafkaProducerService.publishTelemetryEvent(telemetryEvent))
+                .isInstanceOf(TelemetryPublishingException.class)
+                .hasMessage("Failed to publish telemetry event to Kafka")
+                .hasCause(kafkaException);
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getRaw(), "evt-001", telemetryEvent);
     }
 
     @Test
@@ -95,5 +133,10 @@ class KafkaProducerServiceTest {
                         "zone-a"
                 )
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    private SendResult<String, TelemetryEvent> sendResult() {
+        return mock(SendResult.class);
     }
 }


### PR DESCRIPTION
## Summary
Handle common Kafka publishing failures in the ingestion service so publish errors are logged and surfaced as controlled API responses.

## Related Issue
Closes #76

## Issue Requirements Covered
- Kafka publishing failures are handled explicitly
- Producer errors are logged clearly
- Ingestion service returns a controlled response when Kafka publishing fails

## Changes
- Added `TelemetryPublishingException` for controlled Kafka publish failures
- Updated `KafkaProducerService` to wait for Kafka send acknowledgement and log publish failures
- Added exception handling that maps publish failures to `503 Service Unavailable`
- Added tests for immediate Kafka send failures, async send failures, and controller error response behavior

## Testing
Ran ingestion-service test suite:

`.\mvnw.cmd test`

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope

## Summary by Sourcery

Handle Kafka telemetry publish failures in the ingestion service and surface them as controlled API errors.

Bug Fixes:
- Ensure Kafka telemetry publishing failures are converted into a controlled TelemetryPublishingException and not leaked as generic runtime errors.
- Return HTTP 503 Service Unavailable with a consistent error payload when telemetry publishing to Kafka fails after request validation.

Enhancements:
- Make KafkaProducerService wait for send completion, log Kafka publish failures with context, and stop returning the underlying future to callers.

Tests:
- Extend KafkaProducerService tests to cover successful sends, asynchronous send failures, and immediate Kafka send failures.
- Extend TelemetryController tests to verify the 503 Service Unavailable response when Kafka publishing fails.