### PR TITLE
feat(telemetry-processor): configure Kafka consumer properties (#79)

### DIFF
--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/TelemetryProcessorApplication.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/TelemetryProcessorApplication.java
@@ -2,8 +2,10 @@ package com.pulsestream.processor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class TelemetryProcessorApplication {
 
     public static void main(String[] args) {

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/KafkaConsumerConfiguration.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/KafkaConsumerConfiguration.java
@@ -1,0 +1,47 @@
+package com.pulsestream.processor.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+@Configuration
+public class KafkaConsumerConfiguration {
+
+    @Bean
+    public ConsumerFactory<String, Object> telemetryConsumerFactory(
+            TelemetryProcessorKafkaProperties kafkaProperties
+    ) {
+        Map<String, Object> consumerProperties = new HashMap<>();
+
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaProperties.getConsumer().getGroupId());
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getKeyDeserializer());
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getValueDeserializer());
+        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, kafkaProperties.getConsumer().getAutoOffsetReset());
+
+        consumerProperties.putAll(kafkaProperties.getConsumer().getProperties());
+
+        return new DefaultKafkaConsumerFactory<>(consumerProperties);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> telemetryKafkaListenerContainerFactory(
+            ConsumerFactory<String, Object> telemetryConsumerFactory,
+            TelemetryProcessorKafkaProperties kafkaProperties
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(telemetryConsumerFactory);
+        factory.setConcurrency(kafkaProperties.getConsumer().getConcurrency());
+
+        return factory;
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/TelemetryProcessorKafkaProperties.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/TelemetryProcessorKafkaProperties.java
@@ -91,7 +91,7 @@ public class TelemetryProcessorKafkaProperties {
         }
 
         public void setProperties(Map<String, String> properties) {
-            this.properties = properties;
+            this.properties = properties != null ? properties : new LinkedHashMap<>();
         }
     }
 

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/TelemetryProcessorKafkaProperties.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/TelemetryProcessorKafkaProperties.java
@@ -1,0 +1,140 @@
+package com.pulsestream.processor.config;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@ConfigurationProperties(prefix = "pulsestream.kafka")
+public class TelemetryProcessorKafkaProperties {
+
+    private String bootstrapServers = "localhost:9092";
+
+    private final Consumer consumer = new Consumer();
+
+    private final Topics topics = new Topics();
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    public Consumer getConsumer() {
+        return consumer;
+    }
+
+    public Topics getTopics() {
+        return topics;
+    }
+
+    public static class Consumer {
+
+        private String groupId = "telemetry-processor";
+
+        private String keyDeserializer = StringDeserializer.class.getName();
+
+        private String valueDeserializer = JsonDeserializer.class.getName();
+
+        private String autoOffsetReset = "earliest";
+
+        private Integer concurrency = 1;
+
+        private Map<String, String> properties = new LinkedHashMap<>();
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public void setGroupId(String groupId) {
+            this.groupId = groupId;
+        }
+
+        public String getKeyDeserializer() {
+            return keyDeserializer;
+        }
+
+        public void setKeyDeserializer(String keyDeserializer) {
+            this.keyDeserializer = keyDeserializer;
+        }
+
+        public String getValueDeserializer() {
+            return valueDeserializer;
+        }
+
+        public void setValueDeserializer(String valueDeserializer) {
+            this.valueDeserializer = valueDeserializer;
+        }
+
+        public String getAutoOffsetReset() {
+            return autoOffsetReset;
+        }
+
+        public void setAutoOffsetReset(String autoOffsetReset) {
+            this.autoOffsetReset = autoOffsetReset;
+        }
+
+        public Integer getConcurrency() {
+            return concurrency;
+        }
+
+        public void setConcurrency(Integer concurrency) {
+            this.concurrency = concurrency;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, String> properties) {
+            this.properties = properties;
+        }
+    }
+
+    public static class Topics {
+
+        private String raw = "telemetry.events.raw";
+
+        private String processed = "telemetry.events.processed";
+
+        private String anomalies = "telemetry.events.anomalies";
+
+        private String dlq = "telemetry.events.dlq";
+
+        public String getRaw() {
+            return raw;
+        }
+
+        public void setRaw(String raw) {
+            this.raw = raw;
+        }
+
+        public String getProcessed() {
+            return processed;
+        }
+
+        public void setProcessed(String processed) {
+            this.processed = processed;
+        }
+
+        public String getAnomalies() {
+            return anomalies;
+        }
+
+        public void setAnomalies(String anomalies) {
+            this.anomalies = anomalies;
+        }
+
+        public String getDlq() {
+            return dlq;
+        }
+
+        public void setDlq(String dlq) {
+            this.dlq = dlq;
+        }
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryEvent.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryEvent.java
@@ -1,0 +1,4 @@
+package com.pulsestream.processor.model;
+
+public class TelemetryEvent {
+}

--- a/services/telemetry-processor/src/main/resources/application.yml
+++ b/services/telemetry-processor/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
     listener:
       ack-mode: record
     properties:
-      spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.*}
+      spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
       spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
 
 server:
@@ -59,7 +59,7 @@ pulsestream:
       auto-offset-reset: ${PULSESTREAM_KAFKA_CONSUMER_AUTO_OFFSET_RESET:earliest}
       concurrency: ${PULSESTREAM_KAFKA_CONSUMER_CONCURRENCY:1}
       properties:
-        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.*}
+        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
         spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
     topics:
       raw: ${PULSESTREAM_KAFKA_TOPIC_RAW:telemetry.events.raw}

--- a/services/telemetry-processor/src/main/resources/application.yml
+++ b/services/telemetry-processor/src/main/resources/application.yml
@@ -21,10 +21,13 @@ spring:
     consumer:
       group-id: ${PULSESTREAM_KAFKA_CONSUMER_GROUP_ID:telemetry-processor}
       auto-offset-reset: ${PULSESTREAM_KAFKA_CONSUMER_AUTO_OFFSET_RESET:earliest}
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      key-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_KEY_DESERIALIZER:org.apache.kafka.common.serialization.StringDeserializer}
+      value-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DESERIALIZER:org.springframework.kafka.support.serializer.JsonDeserializer}
     listener:
       ack-mode: record
+    properties:
+      spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.*}
+      spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
 
 server:
   port: 8082
@@ -48,8 +51,18 @@ logging:
 
 pulsestream:
   kafka:
+    bootstrap-servers: ${PULSESTREAM_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: ${PULSESTREAM_KAFKA_CONSUMER_GROUP_ID:telemetry-processor}
+      key-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_KEY_DESERIALIZER:org.apache.kafka.common.serialization.StringDeserializer}
+      value-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DESERIALIZER:org.springframework.kafka.support.serializer.JsonDeserializer}
+      auto-offset-reset: ${PULSESTREAM_KAFKA_CONSUMER_AUTO_OFFSET_RESET:earliest}
+      concurrency: ${PULSESTREAM_KAFKA_CONSUMER_CONCURRENCY:1}
+      properties:
+        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.*}
+        spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
     topics:
-      raw: telemetry.events.raw
-      processed: telemetry.events.processed
-      anomalies: telemetry.events.anomalies
-      dlq: telemetry.events.dlq
+      raw: ${PULSESTREAM_KAFKA_TOPIC_RAW:telemetry.events.raw}
+      processed: ${PULSESTREAM_KAFKA_TOPIC_PROCESSED:telemetry.events.processed}
+      anomalies: ${PULSESTREAM_KAFKA_TOPIC_ANOMALIES:telemetry.events.anomalies}
+      dlq: ${PULSESTREAM_KAFKA_TOPIC_DLQ:telemetry.events.dlq}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/config/KafkaConsumerConfigurationTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/config/KafkaConsumerConfigurationTest.java
@@ -1,0 +1,53 @@
+package com.pulsestream.processor.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaConsumerConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration.class)
+            .withPropertyValues(
+                    "pulsestream.kafka.bootstrap-servers=localhost:9092",
+                    "pulsestream.kafka.consumer.group-id=telemetry-processor",
+                    "pulsestream.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer",
+                    "pulsestream.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer",
+                    "pulsestream.kafka.consumer.auto-offset-reset=earliest",
+                    "pulsestream.kafka.consumer.concurrency=2",
+                    "pulsestream.kafka.consumer.properties.spring.json.trusted.packages=com.pulsestream.processor.dto",
+                    "pulsestream.kafka.consumer.properties.spring.json.use.type.headers=false",
+                    "pulsestream.kafka.topics.raw=telemetry.events.raw"
+            );
+
+    @Test
+    void shouldCreateKafkaConsumerInfrastructureForRawTelemetryTopic() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ConsumerFactory.class);
+            assertThat(context).hasSingleBean(ConcurrentKafkaListenerContainerFactory.class);
+
+            TelemetryProcessorKafkaProperties properties =
+                    context.getBean(TelemetryProcessorKafkaProperties.class);
+
+            assertThat(properties.getTopics().getRaw()).isEqualTo("telemetry.events.raw");
+            assertThat(properties.getConsumer().getGroupId()).isEqualTo("telemetry-processor");
+            assertThat(properties.getConsumer().getConcurrency()).isEqualTo(2);
+
+            ConsumerFactory<?, ?> consumerFactory = context.getBean(ConsumerFactory.class);
+
+            assertThat(consumerFactory.getConfigurationProperties())
+                    .containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                    .containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "telemetry-processor")
+                    .containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        });
+    }
+
+    @EnableConfigurationProperties(TelemetryProcessorKafkaProperties.class)
+    static class TestConfiguration extends KafkaConsumerConfiguration {
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/config/TelemetryProcessorKafkaPropertiesTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/config/TelemetryProcessorKafkaPropertiesTest.java
@@ -1,0 +1,38 @@
+package com.pulsestream.processor.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TelemetryProcessorKafkaPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration.class)
+            .withPropertyValues(
+                    "pulsestream.kafka.bootstrap-servers=localhost:9092",
+                    "pulsestream.kafka.consumer.group-id=telemetry-processor",
+                    "pulsestream.kafka.consumer.auto-offset-reset=earliest",
+                    "pulsestream.kafka.consumer.concurrency=2",
+                    "pulsestream.kafka.topics.raw=telemetry.events.raw"
+            );
+
+    @Test
+    void shouldBindKafkaConsumerProperties() {
+        contextRunner.run(context -> {
+            TelemetryProcessorKafkaProperties properties =
+                    context.getBean(TelemetryProcessorKafkaProperties.class);
+
+            assertThat(properties.getBootstrapServers()).isEqualTo("localhost:9092");
+            assertThat(properties.getConsumer().getGroupId()).isEqualTo("telemetry-processor");
+            assertThat(properties.getConsumer().getAutoOffsetReset()).isEqualTo("earliest");
+            assertThat(properties.getConsumer().getConcurrency()).isEqualTo(2);
+            assertThat(properties.getTopics().getRaw()).isEqualTo("telemetry.events.raw");
+        });
+    }
+
+    @EnableConfigurationProperties(TelemetryProcessorKafkaProperties.class)
+    static class TestConfiguration {
+    }
+}


### PR DESCRIPTION
## Summary
Configure Kafka consumer properties for the telemetry-processor service so it is ready to consume telemetry events from the raw Kafka topic.

## Related Issue
Closes #79

## Issue Requirements Covered
- Added Kafka consumer configuration for the telemetry-processor service
- Configured consumer group, deserializers, offset reset behavior, and concurrency
- Added topic configuration for `telemetry.events.raw`
- Kept the implementation limited to configuration only, without adding listener/consumption logic

## Changes
- Added `TelemetryProcessorKafkaProperties` for strongly typed Kafka configuration
- Enabled configuration properties scanning in `TelemetryProcessorApplication`
- Updated `application.yml` with environment-friendly Kafka consumer settings
- Added a configuration binding test for Kafka consumer properties

## Testing
- Ran telemetry-processor tests with:

```bash
./mvnw test
```
## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Introduce strongly-typed, configurable Kafka consumer settings for the telemetry-processor service in preparation for consuming telemetry events.

New Features:
- Add TelemetryProcessorKafkaProperties configuration class to expose Kafka consumer and topic settings via Spring Boot configuration properties.
- Allow telemetry-processor Kafka topics and consumer settings to be customized via environment-backed properties in application.yml.

Tests:
- Add a configuration binding test to verify Kafka consumer and topic properties are correctly bound into TelemetryProcessorKafkaProperties.