### PR TITLE
feat(telemetry-processor): consume raw telemetry events (#80)

### DIFF
--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/consumer/TelemetryEventConsumer.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/consumer/TelemetryEventConsumer.java
@@ -1,0 +1,31 @@
+package com.pulsestream.processor.consumer;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+public class TelemetryEventConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(TelemetryEventConsumer.class);
+
+    @KafkaListener(
+            topics = "${pulsestream.kafka.topics.raw}",
+            groupId = "${pulsestream.kafka.consumer.group-id}",
+            containerFactory = "telemetryKafkaListenerContainerFactory"
+    )
+    public void consumeTelemetryEvent(TelemetryEvent telemetryEvent) {
+        Assert.notNull(telemetryEvent, "telemetryEvent must not be null");
+
+        log.info(
+                "Received telemetry event eventId={} tenantId={} eventType={} source={}",
+                telemetryEvent.eventId(),
+                telemetryEvent.tenantId(),
+                telemetryEvent.eventType(),
+                telemetryEvent.source()
+        );
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryEvent.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryEvent.java
@@ -1,4 +1,14 @@
 package com.pulsestream.processor.model;
 
-public class TelemetryEvent {
+import java.time.Instant;
+
+public record TelemetryEvent(
+        String eventId,
+        String tenantId,
+        String eventType,
+        Instant timestamp,
+        String source,
+        String version,
+        TelemetryPayload payload
+) {
 }

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryPayload.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryPayload.java
@@ -1,0 +1,13 @@
+package com.pulsestream.processor.model;
+
+import java.math.BigDecimal;
+
+public record TelemetryPayload(
+        String deviceId,
+        String deviceType,
+        String metric,
+        BigDecimal value,
+        String unit,
+        String location
+) {
+}

--- a/services/telemetry-processor/src/main/resources/application.yml
+++ b/services/telemetry-processor/src/main/resources/application.yml
@@ -23,11 +23,13 @@ spring:
       auto-offset-reset: ${PULSESTREAM_KAFKA_CONSUMER_AUTO_OFFSET_RESET:earliest}
       key-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_KEY_DESERIALIZER:org.apache.kafka.common.serialization.StringDeserializer}
       value-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DESERIALIZER:org.springframework.kafka.support.serializer.JsonDeserializer}
+      properties:
+        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
+        spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
+        spring.json.value.default.type: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DEFAULT_TYPE:com.pulsestream.processor.model.TelemetryEvent}
+
     listener:
       ack-mode: record
-    properties:
-      spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
-      spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
 
 server:
   port: 8082
@@ -61,6 +63,7 @@ pulsestream:
       properties:
         spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
         spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
+        spring.json.value.default.type: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DEFAULT_TYPE:com.pulsestream.processor.model.TelemetryEvent}
     topics:
       raw: ${PULSESTREAM_KAFKA_TOPIC_RAW:telemetry.events.raw}
       processed: ${PULSESTREAM_KAFKA_TOPIC_PROCESSED:telemetry.events.processed}

--- a/services/telemetry-processor/src/main/resources/application.yml
+++ b/services/telemetry-processor/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
       key-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_KEY_DESERIALIZER:org.apache.kafka.common.serialization.StringDeserializer}
       value-deserializer: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DESERIALIZER:org.springframework.kafka.support.serializer.JsonDeserializer}
       properties:
-        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
+        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.model}
         spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
         spring.json.value.default.type: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DEFAULT_TYPE:com.pulsestream.processor.model.TelemetryEvent}
 
@@ -61,7 +61,7 @@ pulsestream:
       auto-offset-reset: ${PULSESTREAM_KAFKA_CONSUMER_AUTO_OFFSET_RESET:earliest}
       concurrency: ${PULSESTREAM_KAFKA_CONSUMER_CONCURRENCY:1}
       properties:
-        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
+        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.model}
         spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
         spring.json.value.default.type: ${PULSESTREAM_KAFKA_CONSUMER_VALUE_DEFAULT_TYPE:com.pulsestream.processor.model.TelemetryEvent}
     topics:

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventConsumerTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventConsumerTest.java
@@ -1,0 +1,70 @@
+package com.pulsestream.processor.consumer;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.model.TelemetryPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.annotation.KafkaListener;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TelemetryEventConsumerTest {
+
+    private final TelemetryEventConsumer consumer = new TelemetryEventConsumer();
+
+    @Test
+    @DisplayName("should consume telemetry event without throwing")
+    void shouldConsumeTelemetryEventWithoutThrowing() {
+        TelemetryEvent event = telemetryEvent();
+
+        consumer.consumeTelemetryEvent(event);
+    }
+
+    @Test
+    @DisplayName("should reject null telemetry event")
+    void shouldRejectNullTelemetryEvent() {
+        assertThatThrownBy(() -> consumer.consumeTelemetryEvent(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("telemetryEvent must not be null");
+    }
+
+    @Test
+    @DisplayName("should listen to configured raw telemetry topic")
+    void shouldListenToConfiguredRawTelemetryTopic() throws NoSuchMethodException {
+        Method method = TelemetryEventConsumer.class.getMethod(
+                "consumeTelemetryEvent",
+                TelemetryEvent.class
+        );
+
+        KafkaListener kafkaListener = method.getAnnotation(KafkaListener.class);
+
+        assertThat(kafkaListener).isNotNull();
+        assertThat(kafkaListener.topics()).containsExactly("${pulsestream.kafka.topics.raw}");
+        assertThat(kafkaListener.groupId()).isEqualTo("${pulsestream.kafka.consumer.group-id}");
+        assertThat(kafkaListener.containerFactory()).isEqualTo("telemetryKafkaListenerContainerFactory");
+    }
+
+    private TelemetryEvent telemetryEvent() {
+        return new TelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                new TelemetryPayload(
+                        "sensor-1042",
+                        "temperature-sensor",
+                        "temperature",
+                        new BigDecimal("28.4"),
+                        "C",
+                        "zone-a"
+                )
+        );
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventDeserializationTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventDeserializationTest.java
@@ -1,0 +1,61 @@
+package com.pulsestream.processor.consumer;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TelemetryEventDeserializationTest {
+
+    @Test
+    @DisplayName("should deserialize raw telemetry event JSON into telemetry event model")
+    void shouldDeserializeRawTelemetryEventJsonIntoTelemetryEventModel() {
+        String json = """
+                {
+                  "eventId": "evt-001",
+                  "tenantId": "factory-01",
+                  "eventType": "telemetry.reading",
+                  "timestamp": "2026-03-31T12:00:00Z",
+                  "source": "sensor-gateway",
+                  "version": "1.0",
+                  "payload": {
+                    "deviceId": "sensor-1042",
+                    "deviceType": "temperature-sensor",
+                    "metric": "temperature",
+                    "value": 28.4,
+                    "unit": "C",
+                    "location": "zone-a"
+                  }
+                }
+                """;
+
+        JsonDeserializer<TelemetryEvent> deserializer = new JsonDeserializer<>(TelemetryEvent.class);
+        deserializer.addTrustedPackages("com.pulsestream.processor.model");
+
+        TelemetryEvent event = deserializer.deserialize(
+                "telemetry.events.raw",
+                json.getBytes(StandardCharsets.UTF_8)
+        );
+
+        assertThat(event.eventId()).isEqualTo("evt-001");
+        assertThat(event.tenantId()).isEqualTo("factory-01");
+        assertThat(event.eventType()).isEqualTo("telemetry.reading");
+        assertThat(event.timestamp()).isEqualTo(Instant.parse("2026-03-31T12:00:00Z"));
+        assertThat(event.source()).isEqualTo("sensor-gateway");
+        assertThat(event.version()).isEqualTo("1.0");
+
+        assertThat(event.payload()).isNotNull();
+        assertThat(event.payload().deviceId()).isEqualTo("sensor-1042");
+        assertThat(event.payload().deviceType()).isEqualTo("temperature-sensor");
+        assertThat(event.payload().metric()).isEqualTo("temperature");
+        assertThat(event.payload().value()).isEqualByComparingTo(new BigDecimal("28.4"));
+        assertThat(event.payload().unit()).isEqualTo("C");
+        assertThat(event.payload().location()).isEqualTo("zone-a");
+    }
+}


### PR DESCRIPTION
## Summary
Add Kafka consumer logic to the telemetry-processor service so it can receive raw telemetry events from the `telemetry.events.raw` topic.

## Related Issue
Closes #80

## Issue Requirements Covered
- Added Kafka listener method for raw telemetry events
- Added telemetry event model used for deserialization
- Configured JSON deserialization target type for raw telemetry messages
- Added logging for received telemetry events
- Verified listener configuration and event deserialization through tests

## Changes
- Added `TelemetryEvent` model
- Added `TelemetryPayload` model
- Added `TelemetryEventConsumer`
- Updated Kafka consumer JSON properties with default event type
- Added listener unit tests
- Added Kafka JSON deserialization test

## Testing
Ran telemetry-processor tests:

```bash
.\mvnw test
```

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope
## Summary by Sourcery

Add a Kafka-based consumer in the telemetry-processor service to receive and log raw telemetry events using a new typed event model.

New Features:
- Introduce TelemetryEvent and TelemetryPayload models to represent raw telemetry messages.
- Add a TelemetryEventConsumer service that listens to the configured raw telemetry Kafka topic and logs received events.

Enhancements:
- Configure Kafka JSON deserialization to use TelemetryEvent as the default value type for raw telemetry messages.

Tests:
- Add unit tests for the TelemetryEventConsumer listener configuration and null handling.
- Add a JSON deserialization test to verify raw telemetry payloads are mapped into the TelemetryEvent model.
