### PR TITLE
Add processed telemetry event publishing to telemetry processor

### DIFF
--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/KafkaConsumerConfiguration.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/KafkaConsumerConfiguration.java
@@ -10,12 +10,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @Configuration
 public class KafkaConsumerConfiguration {
 
     @Bean
-    public ConsumerFactory<String, Object> telemetryConsumerFactory(
+    public ConsumerFactory<String, TelemetryEvent> telemetryConsumerFactory(
             TelemetryProcessorKafkaProperties kafkaProperties
     ) {
         Map<String, Object> consumerProperties = new HashMap<>();
@@ -25,6 +26,8 @@ public class KafkaConsumerConfiguration {
         consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getKeyDeserializer());
         consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getValueDeserializer());
         consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, kafkaProperties.getConsumer().getAutoOffsetReset());
+        consumerProperties.put(JsonDeserializer.VALUE_DEFAULT_TYPE, TelemetryEvent.class.getName());
+        consumerProperties.put(JsonDeserializer.TRUSTED_PACKAGES, TelemetryEvent.class.getPackageName());
 
         consumerProperties.putAll(kafkaProperties.getConsumer().getProperties());
 
@@ -32,11 +35,11 @@ public class KafkaConsumerConfiguration {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> telemetryKafkaListenerContainerFactory(
-            ConsumerFactory<String, Object> telemetryConsumerFactory,
+    public ConcurrentKafkaListenerContainerFactory<String, TelemetryEvent> telemetryKafkaListenerContainerFactory(
+            ConsumerFactory<String, TelemetryEvent> telemetryConsumerFactory,
             TelemetryProcessorKafkaProperties kafkaProperties
     ) {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+        ConcurrentKafkaListenerContainerFactory<String, TelemetryEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
 
         factory.setConsumerFactory(telemetryConsumerFactory);

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/KafkaProducerConfiguration.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/KafkaProducerConfiguration.java
@@ -1,0 +1,53 @@
+package com.pulsestream.processor.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pulsestream.processor.model.TelemetryEvent;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfiguration {
+
+    @Bean
+    ProducerFactory<String, TelemetryEvent> telemetryProducerFactory(
+            TelemetryProcessorKafkaProperties kafkaProperties,
+            ObjectMapper objectMapper
+    ) {
+        Map<String, Object> producerProperties = new HashMap<>();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        producerProperties.put(ProducerConfig.CLIENT_ID_CONFIG, kafkaProperties.getProducer().getClientId());
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getValueSerializer());
+        producerProperties.put(ProducerConfig.ACKS_CONFIG, kafkaProperties.getProducer().getAcknowledgements());
+        producerProperties.put(ProducerConfig.RETRIES_CONFIG, kafkaProperties.getProducer().getRetries());
+        producerProperties.put(
+                ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG,
+                Math.toIntExact(kafkaProperties.getProducer().getDeliveryTimeout().toMillis())
+        );
+        producerProperties.putAll(kafkaProperties.getProducer().getProperties());
+
+        DefaultKafkaProducerFactory<String, TelemetryEvent> producerFactory =
+                new DefaultKafkaProducerFactory<>(producerProperties);
+
+        if (JsonSerializer.class.getName().equals(kafkaProperties.getProducer().getValueSerializer())) {
+            producerFactory.setValueSerializer(new JsonSerializer<>(objectMapper));
+        }
+
+        return producerFactory;
+    }
+
+    @Bean
+    KafkaTemplate<String, TelemetryEvent> telemetryKafkaTemplate(
+            ProducerFactory<String, TelemetryEvent> telemetryProducerFactory
+    ) {
+        return new KafkaTemplate<>(telemetryProducerFactory);
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/TelemetryProcessorKafkaProperties.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/config/TelemetryProcessorKafkaProperties.java
@@ -4,8 +4,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @ConfigurationProperties(prefix = "pulsestream.kafka")
 public class TelemetryProcessorKafkaProperties {
@@ -13,6 +15,8 @@ public class TelemetryProcessorKafkaProperties {
     private String bootstrapServers = "localhost:9092";
 
     private final Consumer consumer = new Consumer();
+
+    private final Producer producer = new Producer();
 
     private final Topics topics = new Topics();
 
@@ -26,6 +30,10 @@ public class TelemetryProcessorKafkaProperties {
 
     public Consumer getConsumer() {
         return consumer;
+    }
+
+    public Producer getProducer() {
+        return producer;
     }
 
     public Topics getTopics() {
@@ -84,6 +92,89 @@ public class TelemetryProcessorKafkaProperties {
 
         public void setConcurrency(Integer concurrency) {
             this.concurrency = concurrency;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, String> properties) {
+            this.properties = properties != null ? properties : new LinkedHashMap<>();
+        }
+    }
+
+    public static class Producer {
+
+        private String clientId = "telemetry-processor-producer";
+
+        private String keySerializer = StringSerializer.class.getName();
+
+        private String valueSerializer = JsonSerializer.class.getName();
+
+        private String acknowledgements = "all";
+
+        private Integer retries = 3;
+
+        private java.time.Duration deliveryTimeout = java.time.Duration.ofSeconds(30);
+
+        private java.time.Duration publishTimeout = java.time.Duration.ofSeconds(5);
+
+        private Map<String, String> properties = new LinkedHashMap<>();
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public void setClientId(String clientId) {
+            this.clientId = clientId;
+        }
+
+        public String getKeySerializer() {
+            return keySerializer;
+        }
+
+        public void setKeySerializer(String keySerializer) {
+            this.keySerializer = keySerializer;
+        }
+
+        public String getValueSerializer() {
+            return valueSerializer;
+        }
+
+        public void setValueSerializer(String valueSerializer) {
+            this.valueSerializer = valueSerializer;
+        }
+
+        public String getAcknowledgements() {
+            return acknowledgements;
+        }
+
+        public void setAcknowledgements(String acknowledgements) {
+            this.acknowledgements = acknowledgements;
+        }
+
+        public Integer getRetries() {
+            return retries;
+        }
+
+        public void setRetries(Integer retries) {
+            this.retries = retries;
+        }
+
+        public java.time.Duration getDeliveryTimeout() {
+            return deliveryTimeout;
+        }
+
+        public void setDeliveryTimeout(java.time.Duration deliveryTimeout) {
+            this.deliveryTimeout = deliveryTimeout;
+        }
+
+        public java.time.Duration getPublishTimeout() {
+            return publishTimeout;
+        }
+
+        public void setPublishTimeout(java.time.Duration publishTimeout) {
+            this.publishTimeout = publishTimeout;
         }
 
         public Map<String, String> getProperties() {

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/exception/TelemetryPublishingException.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/exception/TelemetryPublishingException.java
@@ -1,0 +1,8 @@
+package com.pulsestream.processor.exception;
+
+public class TelemetryPublishingException extends RuntimeException {
+
+    public TelemetryPublishingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/messaging/TelemetryEventListener.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/messaging/TelemetryEventListener.java
@@ -1,0 +1,25 @@
+package com.pulsestream.processor.messaging;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.service.TelemetryProcessingService;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TelemetryEventListener {
+
+    private final TelemetryProcessingService telemetryProcessingService;
+
+    public TelemetryEventListener(TelemetryProcessingService telemetryProcessingService) {
+        this.telemetryProcessingService = telemetryProcessingService;
+    }
+
+    @KafkaListener(
+            topics = "${pulsestream.kafka.topics.raw}",
+            containerFactory = "telemetryKafkaListenerContainerFactory"
+    )
+    public void onTelemetryEvent(TelemetryEvent telemetryEvent) {
+        telemetryProcessingService.process(telemetryEvent);
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryEvent.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryEvent.java
@@ -1,4 +1,16 @@
 package com.pulsestream.processor.model;
 
-public class TelemetryEvent {
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.Instant;
+
+public record TelemetryEvent(
+        String eventId,
+        String tenantId,
+        String eventType,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) Instant timestamp,
+        String source,
+        String version,
+        TelemetryPayload payload
+) {
 }

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryPayload.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryPayload.java
@@ -1,0 +1,13 @@
+package com.pulsestream.processor.model;
+
+import java.math.BigDecimal;
+
+public record TelemetryPayload(
+        String deviceId,
+        String deviceType,
+        String metric,
+        BigDecimal value,
+        String unit,
+        String location
+) {
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/ProcessedTelemetryPublisher.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/ProcessedTelemetryPublisher.java
@@ -1,0 +1,94 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.config.TelemetryProcessorKafkaProperties;
+import com.pulsestream.processor.exception.TelemetryPublishingException;
+import com.pulsestream.processor.model.TelemetryEvent;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ProcessedTelemetryPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(ProcessedTelemetryPublisher.class);
+
+    private final KafkaTemplate<String, TelemetryEvent> telemetryKafkaTemplate;
+
+    private final TelemetryProcessorKafkaProperties kafkaProperties;
+
+    public ProcessedTelemetryPublisher(
+            KafkaTemplate<String, TelemetryEvent> telemetryKafkaTemplate,
+            TelemetryProcessorKafkaProperties kafkaProperties
+    ) {
+        this.telemetryKafkaTemplate = telemetryKafkaTemplate;
+        this.kafkaProperties = kafkaProperties;
+    }
+
+    public void publish(TelemetryEvent telemetryEvent) {
+        Assert.notNull(telemetryEvent, "telemetryEvent must not be null");
+
+        String topic = kafkaProperties.getTopics().getProcessed();
+        String messageKey = resolveMessageKey(telemetryEvent);
+        long publishTimeoutMillis = publishTimeoutMillis();
+
+        try {
+            telemetryKafkaTemplate.send(topic, messageKey, telemetryEvent)
+                    .get(publishTimeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw publishFailure(telemetryEvent, topic, messageKey, ex);
+        } catch (ExecutionException ex) {
+            throw publishFailure(telemetryEvent, topic, messageKey, ex.getCause() != null ? ex.getCause() : ex);
+        } catch (TimeoutException ex) {
+            TimeoutException timeoutException =
+                    new TimeoutException("Kafka publish did not complete within " + publishTimeoutMillis + " ms");
+            timeoutException.initCause(ex);
+            throw publishFailure(telemetryEvent, topic, messageKey, timeoutException);
+        } catch (RuntimeException ex) {
+            throw publishFailure(telemetryEvent, topic, messageKey, ex);
+        }
+    }
+
+    private String resolveMessageKey(TelemetryEvent telemetryEvent) {
+        if (StringUtils.hasText(telemetryEvent.eventId())) {
+            return telemetryEvent.eventId().trim();
+        }
+
+        Assert.hasText(telemetryEvent.tenantId(),
+                "telemetryEvent must contain a non-blank tenantId when eventId is blank");
+
+        return telemetryEvent.tenantId().trim();
+    }
+
+    private long publishTimeoutMillis() {
+        Duration publishTimeout = kafkaProperties.getProducer().getPublishTimeout();
+        Assert.notNull(publishTimeout, "Kafka producer publish timeout must not be null");
+        Assert.isTrue(publishTimeout.toMillis() > 0,
+                "Kafka producer publish timeout must be greater than zero");
+        return publishTimeout.toMillis();
+    }
+
+    private TelemetryPublishingException publishFailure(
+            TelemetryEvent telemetryEvent,
+            String topic,
+            String messageKey,
+            Throwable cause
+    ) {
+        log.error(
+                "Failed to publish processed telemetry event to Kafka topic={} key={} eventId={}",
+                topic,
+                messageKey,
+                telemetryEvent.eventId(),
+                cause
+        );
+        return new TelemetryPublishingException("Failed to publish telemetry event to Kafka", cause);
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/TelemetryProcessingService.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/TelemetryProcessingService.java
@@ -1,0 +1,60 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.model.TelemetryPayload;
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Service
+public class TelemetryProcessingService {
+
+    private static final String PROCESSED_EVENT_TYPE = "telemetry.processed";
+    private static final String PROCESSED_SOURCE = "telemetry-processor";
+    private static final String DEFAULT_VERSION = "1.0";
+
+    private final ProcessedTelemetryPublisher processedTelemetryPublisher;
+
+    public TelemetryProcessingService(ProcessedTelemetryPublisher processedTelemetryPublisher) {
+        this.processedTelemetryPublisher = processedTelemetryPublisher;
+    }
+
+    public TelemetryEvent process(TelemetryEvent rawEvent) {
+        Assert.notNull(rawEvent, "rawEvent must not be null");
+        Assert.notNull(rawEvent.payload(), "rawEvent payload must not be null");
+
+        TelemetryEvent processedEvent = new TelemetryEvent(
+                normalize(rawEvent.eventId()),
+                normalize(rawEvent.tenantId()),
+                PROCESSED_EVENT_TYPE,
+                rawEvent.timestamp() != null ? rawEvent.timestamp() : Instant.now(),
+                PROCESSED_SOURCE,
+                defaultIfBlank(rawEvent.version(), DEFAULT_VERSION),
+                normalize(rawEvent.payload())
+        );
+
+        processedTelemetryPublisher.publish(processedEvent);
+        return processedEvent;
+    }
+
+    private TelemetryPayload normalize(TelemetryPayload payload) {
+        return new TelemetryPayload(
+                normalize(payload.deviceId()),
+                normalize(payload.deviceType()),
+                normalize(payload.metric()),
+                payload.value(),
+                normalize(payload.unit()),
+                normalize(payload.location())
+        );
+    }
+
+    private String normalize(String value) {
+        return StringUtils.hasText(value) ? value.trim() : value;
+    }
+
+    private String defaultIfBlank(String value, String fallback) {
+        return StringUtils.hasText(value) ? value.trim() : fallback;
+    }
+}

--- a/services/telemetry-processor/src/main/resources/application.yml
+++ b/services/telemetry-processor/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
     listener:
       ack-mode: record
     properties:
-      spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
+      spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.model}
       spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
 
 server:
@@ -59,8 +59,17 @@ pulsestream:
       auto-offset-reset: ${PULSESTREAM_KAFKA_CONSUMER_AUTO_OFFSET_RESET:earliest}
       concurrency: ${PULSESTREAM_KAFKA_CONSUMER_CONCURRENCY:1}
       properties:
-        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.dto}
+        spring.json.trusted.packages: ${PULSESTREAM_KAFKA_CONSUMER_TRUSTED_PACKAGES:com.pulsestream.processor.model}
         spring.json.use.type.headers: ${PULSESTREAM_KAFKA_CONSUMER_USE_TYPE_HEADERS:false}
+    producer:
+      client-id: ${PULSESTREAM_KAFKA_PRODUCER_CLIENT_ID:telemetry-processor-producer}
+      key-serializer: ${PULSESTREAM_KAFKA_PRODUCER_KEY_SERIALIZER:org.apache.kafka.common.serialization.StringSerializer}
+      value-serializer: ${PULSESTREAM_KAFKA_PRODUCER_VALUE_SERIALIZER:org.springframework.kafka.support.serializer.JsonSerializer}
+      acknowledgements: ${PULSESTREAM_KAFKA_PRODUCER_ACKS:all}
+      retries: ${PULSESTREAM_KAFKA_PRODUCER_RETRIES:3}
+      delivery-timeout: ${PULSESTREAM_KAFKA_PRODUCER_DELIVERY_TIMEOUT:30s}
+      publish-timeout: ${PULSESTREAM_KAFKA_PRODUCER_PUBLISH_TIMEOUT:5s}
+      properties: {}
     topics:
       raw: ${PULSESTREAM_KAFKA_TOPIC_RAW:telemetry.events.raw}
       processed: ${PULSESTREAM_KAFKA_TOPIC_PROCESSED:telemetry.events.processed}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/config/KafkaProducerConfigurationTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/config/KafkaProducerConfigurationTest.java
@@ -1,0 +1,44 @@
+package com.pulsestream.processor.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.kafka.core.ProducerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaProducerConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(org.springframework.boot.autoconfigure.AutoConfigurations.of(JacksonAutoConfiguration.class))
+            .withUserConfiguration(TestConfiguration.class)
+            .withPropertyValues(
+                    "pulsestream.kafka.bootstrap-servers=localhost:9092",
+                    "pulsestream.kafka.producer.client-id=telemetry-processor-producer",
+                    "pulsestream.kafka.producer.acks=all",
+                    "pulsestream.kafka.producer.retries=5",
+                    "pulsestream.kafka.producer.delivery-timeout=45s"
+            );
+
+    @Test
+    void shouldCreateKafkaProducerInfrastructureForProcessedTelemetryTopic() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ProducerFactory.class);
+
+            ProducerFactory<?, ?> producerFactory = context.getBean(ProducerFactory.class);
+
+            assertThat(producerFactory.getConfigurationProperties())
+                    .containsEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                    .containsEntry(ProducerConfig.CLIENT_ID_CONFIG, "telemetry-processor-producer")
+                    .containsEntry(ProducerConfig.ACKS_CONFIG, "all")
+                    .containsEntry(ProducerConfig.RETRIES_CONFIG, 5)
+                    .containsEntry(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 45000);
+        });
+    }
+
+    @EnableConfigurationProperties(TelemetryProcessorKafkaProperties.class)
+    static class TestConfiguration extends KafkaProducerConfiguration {
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/ProcessedTelemetryPublisherTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/ProcessedTelemetryPublisherTest.java
@@ -1,0 +1,162 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.config.TelemetryProcessorKafkaProperties;
+import com.pulsestream.processor.exception.TelemetryPublishingException;
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.model.TelemetryPayload;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.kafka.common.KafkaException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessedTelemetryPublisherTest {
+
+    @Mock
+    private KafkaTemplate<String, TelemetryEvent> kafkaTemplate;
+
+    private TelemetryProcessorKafkaProperties kafkaProperties;
+
+    private ProcessedTelemetryPublisher processedTelemetryPublisher;
+
+    @BeforeEach
+    void setUp() {
+        kafkaProperties = new TelemetryProcessorKafkaProperties();
+        processedTelemetryPublisher = new ProcessedTelemetryPublisher(kafkaTemplate, kafkaProperties);
+    }
+
+    @Test
+    @DisplayName("should publish processed telemetry event to configured topic")
+    void shouldPublishProcessedTelemetryEventToConfiguredTopic() {
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        CompletableFuture<SendResult<String, TelemetryEvent>> future = CompletableFuture.completedFuture(null);
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent))
+                .thenReturn(future);
+
+        assertThatCode(() -> processedTelemetryPublisher.publish(telemetryEvent))
+                .doesNotThrowAnyException();
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should throw controlled exception when Kafka send completes with failure")
+    void shouldThrowControlledExceptionWhenKafkaSendCompletesWithFailure() {
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        CompletableFuture<SendResult<String, TelemetryEvent>> future = new CompletableFuture<>();
+        KafkaException kafkaException = new KafkaException("broker unavailable");
+        future.completeExceptionally(kafkaException);
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent))
+                .thenReturn(future);
+
+        assertThatThrownBy(() -> processedTelemetryPublisher.publish(telemetryEvent))
+                .isInstanceOf(TelemetryPublishingException.class)
+                .hasMessage("Failed to publish telemetry event to Kafka")
+                .hasCause(kafkaException);
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should throw controlled exception when Kafka send fails immediately")
+    void shouldThrowControlledExceptionWhenKafkaSendFailsImmediately() {
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        KafkaException kafkaException = new KafkaException("producer unavailable");
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent))
+                .thenThrow(kafkaException);
+
+        assertThatThrownBy(() -> processedTelemetryPublisher.publish(telemetryEvent))
+                .isInstanceOf(TelemetryPublishingException.class)
+                .hasMessage("Failed to publish telemetry event to Kafka")
+                .hasCause(kafkaException);
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should throw controlled exception when Kafka send does not complete before timeout")
+    void shouldThrowControlledExceptionWhenKafkaSendDoesNotCompleteBeforeTimeout() {
+        TelemetryEvent telemetryEvent = telemetryEvent("evt-001", "factory-01");
+        CompletableFuture<SendResult<String, TelemetryEvent>> future = new CompletableFuture<>();
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent))
+                .thenReturn(future);
+
+        assertThatThrownBy(() -> processedTelemetryPublisher.publish(telemetryEvent))
+                .isInstanceOf(TelemetryPublishingException.class)
+                .hasMessage("Failed to publish telemetry event to Kafka")
+                .hasCauseInstanceOf(TimeoutException.class);
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getProcessed(), "evt-001", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should use tenant identifier as message key when event id is blank")
+    void shouldUseTenantIdentifierAsMessageKeyWhenEventIdIsBlank() {
+        TelemetryEvent telemetryEvent = telemetryEvent(" ", "factory-01");
+        CompletableFuture<SendResult<String, TelemetryEvent>> future = CompletableFuture.completedFuture(null);
+
+        when(kafkaTemplate.send(kafkaProperties.getTopics().getProcessed(), "factory-01", telemetryEvent))
+                .thenReturn(future);
+
+        assertThatCode(() -> processedTelemetryPublisher.publish(telemetryEvent))
+                .doesNotThrowAnyException();
+
+        verify(kafkaTemplate).send(kafkaProperties.getTopics().getProcessed(), "factory-01", telemetryEvent);
+    }
+
+    @Test
+    @DisplayName("should reject blank tenant id when event id is blank")
+    void shouldRejectBlankTenantIdWhenEventIdIsBlank() {
+        TelemetryEvent telemetryEvent = telemetryEvent(" ", " ");
+
+        assertThatThrownBy(() -> processedTelemetryPublisher.publish(telemetryEvent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("telemetryEvent must contain a non-blank tenantId when eventId is blank");
+    }
+
+    @Test
+    @DisplayName("should reject null telemetry events")
+    void shouldRejectNullTelemetryEvents() {
+        assertThatThrownBy(() -> processedTelemetryPublisher.publish(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("telemetryEvent must not be null");
+    }
+
+    private TelemetryEvent telemetryEvent(String eventId, String tenantId) {
+        return new TelemetryEvent(
+                eventId,
+                tenantId,
+                "telemetry.processed",
+                Instant.parse("2026-03-15T12:05:21Z"),
+                "telemetry-processor",
+                "1.0",
+                new TelemetryPayload(
+                        "sensor_1042",
+                        "temperature-sensor",
+                        "temperature",
+                        BigDecimal.valueOf(28.4),
+                        "C",
+                        "zone-a"
+                )
+        );
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryProcessingServiceTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryProcessingServiceTest.java
@@ -1,0 +1,84 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.model.TelemetryPayload;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TelemetryProcessingServiceTest {
+
+    @Mock
+    private ProcessedTelemetryPublisher processedTelemetryPublisher;
+
+    @Test
+    @DisplayName("should normalize raw telemetry event and publish processed event")
+    void shouldNormalizeRawTelemetryEventAndPublishProcessedEvent() {
+        TelemetryProcessingService service = new TelemetryProcessingService(processedTelemetryPublisher);
+        TelemetryEvent rawEvent = new TelemetryEvent(
+                " evt-001 ",
+                " factory-01 ",
+                "telemetry.reading",
+                Instant.parse("2026-03-15T12:05:21Z"),
+                "sensor-gateway",
+                " ",
+                new TelemetryPayload(
+                        " sensor_1042 ",
+                        " temperature-sensor ",
+                        " temperature ",
+                        BigDecimal.valueOf(28.4),
+                        " C ",
+                        " zone-a "
+                )
+        );
+
+        TelemetryEvent processedEvent = service.process(rawEvent);
+
+        ArgumentCaptor<TelemetryEvent> captor = ArgumentCaptor.forClass(TelemetryEvent.class);
+        verify(processedTelemetryPublisher).publish(captor.capture());
+
+        TelemetryEvent publishedEvent = captor.getValue();
+        assertThat(processedEvent).isEqualTo(publishedEvent);
+        assertThat(publishedEvent.eventId()).isEqualTo("evt-001");
+        assertThat(publishedEvent.tenantId()).isEqualTo("factory-01");
+        assertThat(publishedEvent.eventType()).isEqualTo("telemetry.processed");
+        assertThat(publishedEvent.timestamp()).isEqualTo(Instant.parse("2026-03-15T12:05:21Z"));
+        assertThat(publishedEvent.source()).isEqualTo("telemetry-processor");
+        assertThat(publishedEvent.version()).isEqualTo("1.0");
+        assertThat(publishedEvent.payload().deviceId()).isEqualTo("sensor_1042");
+        assertThat(publishedEvent.payload().deviceType()).isEqualTo("temperature-sensor");
+        assertThat(publishedEvent.payload().metric()).isEqualTo("temperature");
+        assertThat(publishedEvent.payload().unit()).isEqualTo("C");
+        assertThat(publishedEvent.payload().location()).isEqualTo("zone-a");
+    }
+
+    @Test
+    @DisplayName("should reject raw telemetry events without payload")
+    void shouldRejectRawTelemetryEventsWithoutPayload() {
+        TelemetryProcessingService service = new TelemetryProcessingService(processedTelemetryPublisher);
+        TelemetryEvent rawEvent = new TelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-15T12:05:21Z"),
+                "sensor-gateway",
+                "1.0",
+                null
+        );
+
+        assertThatThrownBy(() -> service.process(rawEvent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("rawEvent payload must not be null");
+    }
+}


### PR DESCRIPTION
## Summary
Publish normalized telemetry events from the telemetry processor to `telemetry.events.processed` using the canonical event envelope and reliable Kafka producer behavior.

## Related Issue
Closes #83

## Issue Requirements Covered
- events are published to `telemetry.events.processed`
- published events match the platform telemetry event schema
- publishing includes reliable broker acknowledgement, retry, and timeout handling

## Changes
- added typed telemetry event and payload models to the telemetry processor
- added Kafka producer configuration and processor Kafka producer properties
- added a processed telemetry publisher with controlled publish failure handling
- added a Kafka listener and processing service to consume raw events, normalize fields, and emit `telemetry.processed`
- added tests for producer configuration, publish reliability behavior, and normalization flow

## Testing
Ran `./mvnw.cmd test` in `services/telemetry-processor`.

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope

## Summary by Sourcery

Add support for consuming raw telemetry events, normalizing them into a canonical event format, and reliably publishing processed telemetry events to Kafka.

New Features:
- Introduce canonical TelemetryEvent and TelemetryPayload models for normalized telemetry data.
- Add a Kafka listener and processing service to transform raw telemetry events into processed telemetry events and emit them to the processed topic.
- Add a dedicated processed telemetry publisher that sends normalized events to the configured Kafka topic using a typed Kafka template.

Enhancements:
- Extend telemetry Kafka configuration with typed producer settings, including client ID, serializers, acknowledgements, retries, and timeouts.
- Update consumer configuration to use strongly typed TelemetryEvent deserialization and adjust trusted JSON packages in application configuration.

Tests:
- Add unit tests covering Kafka producer configuration, processed telemetry publishing behavior under success, failure, and timeout scenarios, and the telemetry normalization and publishing flow.