### PR TITLE
feat(telemetry-processor): normalize raw telemetry events (#81)

### DIFF
--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/consumer/TelemetryEventConsumer.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/consumer/TelemetryEventConsumer.java
@@ -1,6 +1,8 @@
 package com.pulsestream.processor.consumer;
 
+import com.pulsestream.processor.model.NormalizedTelemetryEvent;
 import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.service.TelemetryNormalizationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -12,6 +14,12 @@ public class TelemetryEventConsumer {
 
     private static final Logger log = LoggerFactory.getLogger(TelemetryEventConsumer.class);
 
+    private final TelemetryNormalizationService normalizationService;
+
+    public TelemetryEventConsumer(TelemetryNormalizationService normalizationService) {
+        this.normalizationService = normalizationService;
+    }
+
     @KafkaListener(
             topics = "${pulsestream.kafka.topics.raw}",
             groupId = "${pulsestream.kafka.consumer.group-id}",
@@ -20,12 +28,15 @@ public class TelemetryEventConsumer {
     public void consumeTelemetryEvent(TelemetryEvent telemetryEvent) {
         Assert.notNull(telemetryEvent, "telemetryEvent must not be null");
 
+        NormalizedTelemetryEvent normalizedEvent =
+                normalizationService.normalize(telemetryEvent);
+
         log.info(
-                "Received telemetry event eventId={} tenantId={} eventType={} source={}",
-                telemetryEvent.eventId(),
-                telemetryEvent.tenantId(),
-                telemetryEvent.eventType(),
-                telemetryEvent.source()
+                "Normalized telemetry event eventId={} tenantId={} metric={} unit={}",
+                normalizedEvent.eventId(),
+                normalizedEvent.tenantId(),
+                normalizedEvent.metric(),
+                normalizedEvent.unit()
         );
     }
 }

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/NormalizedTelemetryEvent.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/NormalizedTelemetryEvent.java
@@ -1,0 +1,20 @@
+package com.pulsestream.processor.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record NormalizedTelemetryEvent(
+        String eventId,
+        String tenantId,
+        String eventType,
+        Instant timestamp,
+        String source,
+        String version,
+        String deviceId,
+        String deviceType,
+        String metric,
+        BigDecimal value,
+        String unit,
+        String location
+) {
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/TelemetryNormalizationService.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/TelemetryNormalizationService.java
@@ -1,0 +1,43 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.model.NormalizedTelemetryEvent;
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.model.TelemetryPayload;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.Locale;
+
+@Service
+public class TelemetryNormalizationService {
+
+    public NormalizedTelemetryEvent normalize(TelemetryEvent event) {
+        Assert.notNull(event, "telemetry event must not be null");
+        Assert.notNull(event.payload(), "telemetry payload must not be null");
+
+        TelemetryPayload payload = event.payload();
+
+        return new NormalizedTelemetryEvent(
+                trim(event.eventId()),
+                trim(event.tenantId()),
+                normalizeToken(event.eventType()),
+                event.timestamp(),
+                trim(event.source()),
+                trim(event.version()),
+                trim(payload.deviceId()),
+                normalizeToken(payload.deviceType()),
+                normalizeToken(payload.metric()),
+                payload.value(),
+                normalizeToken(payload.unit()),
+                trim(payload.location())
+        );
+    }
+
+    private String trim(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private String normalizeToken(String value) {
+        return value == null ? null : value.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventConsumerTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventConsumerTest.java
@@ -1,7 +1,9 @@
 package com.pulsestream.processor.consumer;
 
+import com.pulsestream.processor.model.NormalizedTelemetryEvent;
 import com.pulsestream.processor.model.TelemetryEvent;
 import com.pulsestream.processor.model.TelemetryPayload;
+import com.pulsestream.processor.service.TelemetryNormalizationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -12,17 +14,30 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class TelemetryEventConsumerTest {
 
-    private final TelemetryEventConsumer consumer = new TelemetryEventConsumer();
+    private final TelemetryNormalizationService normalizationService =
+            mock(TelemetryNormalizationService.class);
+
+    private final TelemetryEventConsumer consumer =
+            new TelemetryEventConsumer(normalizationService);
 
     @Test
-    @DisplayName("should consume telemetry event without throwing")
-    void shouldConsumeTelemetryEventWithoutThrowing() {
+    @DisplayName("should consume telemetry event and invoke normalization without throwing")
+    void shouldConsumeTelemetryEventAndInvokeNormalizationWithoutThrowing() {
         TelemetryEvent event = telemetryEvent();
+        NormalizedTelemetryEvent normalizedEvent = normalizedTelemetryEvent();
+
+        when(normalizationService.normalize(event)).thenReturn(normalizedEvent);
 
         consumer.consumeTelemetryEvent(event);
+
+        verify(normalizationService).normalize(event);
     }
 
     @Test
@@ -31,6 +46,8 @@ class TelemetryEventConsumerTest {
         assertThatThrownBy(() -> consumer.consumeTelemetryEvent(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("telemetryEvent must not be null");
+
+        verifyNoInteractions(normalizationService);
     }
 
     @Test
@@ -65,6 +82,23 @@ class TelemetryEventConsumerTest {
                         "C",
                         "zone-a"
                 )
+        );
+    }
+
+    private NormalizedTelemetryEvent normalizedTelemetryEvent() {
+        return new NormalizedTelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                "sensor-1042",
+                "temperature-sensor",
+                "temperature",
+                new BigDecimal("28.4"),
+                "c",
+                "zone-a"
         );
     }
 }

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryNormalizationServiceTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryNormalizationServiceTest.java
@@ -1,0 +1,112 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.model.NormalizedTelemetryEvent;
+import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.model.TelemetryPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TelemetryNormalizationServiceTest {
+
+    private final TelemetryNormalizationService normalizationService =
+            new TelemetryNormalizationService();
+
+    @Test
+    @DisplayName("should normalize telemetry event into consistent internal format")
+    void shouldNormalizeTelemetryEventIntoConsistentInternalFormat() {
+        TelemetryEvent rawEvent = new TelemetryEvent(
+                " evt-001 ",
+                " factory-01 ",
+                " Telemetry.Reading ",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                " sensor-gateway ",
+                " 1.0 ",
+                new TelemetryPayload(
+                        " sensor-1042 ",
+                        " Temperature-Sensor ",
+                        " Temperature ",
+                        new BigDecimal("28.4"),
+                        " C ",
+                        " zone-a "
+                )
+        );
+
+        NormalizedTelemetryEvent normalizedEvent =
+                normalizationService.normalize(rawEvent);
+
+        assertThat(normalizedEvent.eventId()).isEqualTo("evt-001");
+        assertThat(normalizedEvent.tenantId()).isEqualTo("factory-01");
+        assertThat(normalizedEvent.eventType()).isEqualTo("telemetry.reading");
+        assertThat(normalizedEvent.timestamp()).isEqualTo(Instant.parse("2026-03-31T12:00:00Z"));
+        assertThat(normalizedEvent.source()).isEqualTo("sensor-gateway");
+        assertThat(normalizedEvent.version()).isEqualTo("1.0");
+        assertThat(normalizedEvent.deviceId()).isEqualTo("sensor-1042");
+        assertThat(normalizedEvent.deviceType()).isEqualTo("temperature-sensor");
+        assertThat(normalizedEvent.metric()).isEqualTo("temperature");
+        assertThat(normalizedEvent.value()).isEqualByComparingTo(new BigDecimal("28.4"));
+        assertThat(normalizedEvent.unit()).isEqualTo("c");
+        assertThat(normalizedEvent.location()).isEqualTo("zone-a");
+    }
+
+    @Test
+    @DisplayName("should preserve numeric value and timestamp during normalization")
+    void shouldPreserveNumericValueAndTimestampDuringNormalization() {
+        Instant timestamp = Instant.parse("2026-03-31T12:00:00Z");
+        BigDecimal value = new BigDecimal("28.4");
+
+        TelemetryEvent rawEvent = new TelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                timestamp,
+                "sensor-gateway",
+                "1.0",
+                new TelemetryPayload(
+                        "sensor-1042",
+                        "temperature-sensor",
+                        "temperature",
+                        value,
+                        "c",
+                        "zone-a"
+                )
+        );
+
+        NormalizedTelemetryEvent normalizedEvent =
+                normalizationService.normalize(rawEvent);
+
+        assertThat(normalizedEvent.timestamp()).isEqualTo(timestamp);
+        assertThat(normalizedEvent.value()).isEqualByComparingTo(value);
+    }
+
+    @Test
+    @DisplayName("should reject null telemetry event")
+    void shouldRejectNullTelemetryEvent() {
+        assertThatThrownBy(() -> normalizationService.normalize(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("telemetry event must not be null");
+    }
+
+    @Test
+    @DisplayName("should reject telemetry event with null payload")
+    void shouldRejectTelemetryEventWithNullPayload() {
+        TelemetryEvent rawEvent = new TelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                null
+        );
+
+        assertThatThrownBy(() -> normalizationService.normalize(rawEvent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("telemetry payload must not be null");
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryNormalizationServiceTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryNormalizationServiceTest.java
@@ -109,4 +109,41 @@ class TelemetryNormalizationServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("telemetry payload must not be null");
     }
+
+    @Test
+    @DisplayName("should preserve null optional fields during normalization")
+    void shouldPreserveNullOptionalFieldsDuringNormalization() {
+        TelemetryEvent rawEvent = new TelemetryEvent(
+                null,
+                " factory-01 ",
+                null,
+                Instant.parse("2026-03-31T12:00:00Z"),
+                null,
+                " 1.0 ",
+                new TelemetryPayload(
+                        null,
+                        null,
+                        " Temperature ",
+                        new BigDecimal("28.4"),
+                        null,
+                        null
+                )
+        );
+
+        NormalizedTelemetryEvent normalizedEvent =
+                normalizationService.normalize(rawEvent);
+
+        assertThat(normalizedEvent.eventId()).isNull();
+        assertThat(normalizedEvent.tenantId()).isEqualTo("factory-01");
+        assertThat(normalizedEvent.eventType()).isNull();
+        assertThat(normalizedEvent.timestamp()).isEqualTo(Instant.parse("2026-03-31T12:00:00Z"));
+        assertThat(normalizedEvent.source()).isNull();
+        assertThat(normalizedEvent.version()).isEqualTo("1.0");
+        assertThat(normalizedEvent.deviceId()).isNull();
+        assertThat(normalizedEvent.deviceType()).isNull();
+        assertThat(normalizedEvent.metric()).isEqualTo("temperature");
+        assertThat(normalizedEvent.value()).isEqualByComparingTo(new BigDecimal("28.4"));
+        assertThat(normalizedEvent.unit()).isNull();
+        assertThat(normalizedEvent.location()).isNull();
+    }
 }


### PR DESCRIPTION
## Summary
Add telemetry normalization logic to transform raw telemetry events into a consistent internal format for downstream processing.

## Related Issue
Closes #81

## Issue Requirements Covered
- Added normalized telemetry event model
- Added normalization service for raw telemetry events
- Added deterministic mapping from raw event to normalized event
- Preserved timestamp and numeric value during transformation
- Added tests proving normalization behavior and null input handling

## Changes
- Added `NormalizedTelemetryEvent`
- Added `TelemetryNormalizationService`
- Updated `TelemetryEventConsumer` to invoke normalization after consuming raw events
- Added unit tests for normalization rules
- Updated consumer test coverage for normalization integration

## Testing
Ran telemetry-processor tests:

```bash
.\mvnw test
```

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Introduce a telemetry normalization layer and integrate it into the telemetry event consumer to produce a consistent internal event format for downstream processing.

New Features:
- Add NormalizedTelemetryEvent model to represent standardized telemetry data.
- Add TelemetryNormalizationService to convert raw telemetry events into normalized events.

Enhancements:
- Update TelemetryEventConsumer to normalize incoming telemetry events and log normalized attributes instead of raw fields.

Tests:
- Add unit tests for TelemetryNormalizationService covering normalization rules, value/timestamp preservation, and null handling.
- Extend TelemetryEventConsumer tests to verify normalization is invoked and not called for null input.