### PR TITLE
feat(telemetry-processor): add basic anomaly detection logic (#82)

### DIFF
--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/consumer/TelemetryEventConsumer.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/consumer/TelemetryEventConsumer.java
@@ -1,7 +1,9 @@
 package com.pulsestream.processor.consumer;
 
 import com.pulsestream.processor.model.NormalizedTelemetryEvent;
+import com.pulsestream.processor.model.TelemetryAnomalyResult;
 import com.pulsestream.processor.model.TelemetryEvent;
+import com.pulsestream.processor.service.TelemetryAnomalyDetectionService;
 import com.pulsestream.processor.service.TelemetryNormalizationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,9 +17,14 @@ public class TelemetryEventConsumer {
     private static final Logger log = LoggerFactory.getLogger(TelemetryEventConsumer.class);
 
     private final TelemetryNormalizationService normalizationService;
+    private final TelemetryAnomalyDetectionService anomalyDetectionService;
 
-    public TelemetryEventConsumer(TelemetryNormalizationService normalizationService) {
+    public TelemetryEventConsumer(
+            TelemetryNormalizationService normalizationService,
+            TelemetryAnomalyDetectionService anomalyDetectionService
+    ) {
         this.normalizationService = normalizationService;
+        this.anomalyDetectionService = anomalyDetectionService;
     }
 
     @KafkaListener(
@@ -31,8 +38,22 @@ public class TelemetryEventConsumer {
         NormalizedTelemetryEvent normalizedEvent =
                 normalizationService.normalize(telemetryEvent);
 
+        TelemetryAnomalyResult anomalyResult =
+                anomalyDetectionService.detect(normalizedEvent);
+
+        if (anomalyResult.anomalous()) {
+            log.warn(
+                    "Detected telemetry anomaly eventId={} tenantId={} severity={} reasons={}",
+                    normalizedEvent.eventId(),
+                    normalizedEvent.tenantId(),
+                    anomalyResult.severity(),
+                    anomalyResult.reasons()
+            );
+            return;
+        }
+
         log.info(
-                "Normalized telemetry event eventId={} tenantId={} metric={} unit={}",
+                "Processed normal telemetry event eventId={} tenantId={} metric={} unit={}",
                 normalizedEvent.eventId(),
                 normalizedEvent.tenantId(),
                 normalizedEvent.metric(),

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/AnomalySeverity.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/AnomalySeverity.java
@@ -1,0 +1,7 @@
+package com.pulsestream.processor.model;
+
+public enum AnomalySeverity {
+    NONE,
+    WARNING,
+    CRITICAL
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryAnomalyResult.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/model/TelemetryAnomalyResult.java
@@ -1,0 +1,22 @@
+package com.pulsestream.processor.model;
+
+import java.util.List;
+
+public record TelemetryAnomalyResult(
+        NormalizedTelemetryEvent event,
+        boolean anomalous,
+        AnomalySeverity severity,
+        List<String> reasons
+) {
+    public static TelemetryAnomalyResult normal(NormalizedTelemetryEvent event) {
+        return new TelemetryAnomalyResult(event, false, AnomalySeverity.NONE, List.of());
+    }
+
+    public static TelemetryAnomalyResult anomalous(
+            NormalizedTelemetryEvent event,
+            AnomalySeverity severity,
+            List<String> reasons
+    ) {
+        return new TelemetryAnomalyResult(event, true, severity, List.copyOf(reasons));
+    }
+}

--- a/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/TelemetryAnomalyDetectionService.java
+++ b/services/telemetry-processor/src/main/java/com/pulsestream/processor/service/TelemetryAnomalyDetectionService.java
@@ -1,0 +1,77 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.model.AnomalySeverity;
+import com.pulsestream.processor.model.NormalizedTelemetryEvent;
+import com.pulsestream.processor.model.TelemetryAnomalyResult;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class TelemetryAnomalyDetectionService {
+
+    private static final BigDecimal MAX_TEMPERATURE = new BigDecimal("80");
+    private static final BigDecimal MIN_TEMPERATURE = new BigDecimal("-40");
+
+    public TelemetryAnomalyResult detect(NormalizedTelemetryEvent event) {
+        Assert.notNull(event, "normalized telemetry event must not be null");
+
+        List<String> reasons = new ArrayList<>();
+
+        if (!StringUtils.hasText(event.tenantId())) {
+            reasons.add("tenantId is required");
+        }
+
+        if (!StringUtils.hasText(event.deviceId())) {
+            reasons.add("deviceId is required");
+        }
+
+        if (!StringUtils.hasText(event.metric())) {
+            reasons.add("metric is required");
+        }
+
+        if (event.value() == null) {
+            reasons.add("value is required");
+        }
+
+        if (event.value() != null && "temperature".equals(event.metric())) {
+            if (event.value().compareTo(MAX_TEMPERATURE) > 0) {
+                reasons.add("temperature is above maximum threshold");
+            }
+
+            if (event.value().compareTo(MIN_TEMPERATURE) < 0) {
+                reasons.add("temperature is below minimum threshold");
+            }
+        }
+
+        if (reasons.isEmpty()) {
+            return TelemetryAnomalyResult.normal(event);
+        }
+
+        return TelemetryAnomalyResult.anomalous(
+                event,
+                resolveSeverity(reasons),
+                reasons
+        );
+    }
+
+    private AnomalySeverity resolveSeverity(List<String> reasons) {
+        boolean hasMissingCriticalField = reasons.stream()
+                .anyMatch(reason ->
+                        reason.contains("tenantId")
+                                || reason.contains("deviceId")
+                                || reason.contains("metric")
+                                || reason.contains("value")
+                );
+
+        if (hasMissingCriticalField) {
+            return AnomalySeverity.CRITICAL;
+        }
+
+        return AnomalySeverity.WARNING;
+    }
+}

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventConsumerTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/consumer/TelemetryEventConsumerTest.java
@@ -1,8 +1,10 @@
 package com.pulsestream.processor.consumer;
 
 import com.pulsestream.processor.model.NormalizedTelemetryEvent;
+import com.pulsestream.processor.model.TelemetryAnomalyResult;
 import com.pulsestream.processor.model.TelemetryEvent;
 import com.pulsestream.processor.model.TelemetryPayload;
+import com.pulsestream.processor.service.TelemetryAnomalyDetectionService;
 import com.pulsestream.processor.service.TelemetryNormalizationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,21 +25,26 @@ class TelemetryEventConsumerTest {
 
     private final TelemetryNormalizationService normalizationService =
             mock(TelemetryNormalizationService.class);
+    private final TelemetryAnomalyDetectionService anomalyDetectionService =
+            mock(TelemetryAnomalyDetectionService.class);
 
     private final TelemetryEventConsumer consumer =
-            new TelemetryEventConsumer(normalizationService);
+            new TelemetryEventConsumer(normalizationService, anomalyDetectionService);
 
     @Test
-    @DisplayName("should consume telemetry event and invoke normalization without throwing")
-    void shouldConsumeTelemetryEventAndInvokeNormalizationWithoutThrowing() {
+    @DisplayName("should consume telemetry event and invoke normalization and anomaly detection without throwing")
+    void shouldConsumeTelemetryEventAndInvokeNormalizationAndAnomalyDetectionWithoutThrowing() {
         TelemetryEvent event = telemetryEvent();
         NormalizedTelemetryEvent normalizedEvent = normalizedTelemetryEvent();
+        TelemetryAnomalyResult anomalyResult = TelemetryAnomalyResult.normal(normalizedEvent);
 
         when(normalizationService.normalize(event)).thenReturn(normalizedEvent);
+        when(anomalyDetectionService.detect(normalizedEvent)).thenReturn(anomalyResult);
 
         consumer.consumeTelemetryEvent(event);
 
         verify(normalizationService).normalize(event);
+        verify(anomalyDetectionService).detect(normalizedEvent);
     }
 
     @Test
@@ -48,6 +55,7 @@ class TelemetryEventConsumerTest {
                 .hasMessage("telemetryEvent must not be null");
 
         verifyNoInteractions(normalizationService);
+        verifyNoInteractions(anomalyDetectionService);
     }
 
     @Test

--- a/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryAnomalyDetectionServiceTest.java
+++ b/services/telemetry-processor/src/test/java/com/pulsestream/processor/service/TelemetryAnomalyDetectionServiceTest.java
@@ -1,0 +1,124 @@
+package com.pulsestream.processor.service;
+
+import com.pulsestream.processor.model.AnomalySeverity;
+import com.pulsestream.processor.model.NormalizedTelemetryEvent;
+import com.pulsestream.processor.model.TelemetryAnomalyResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TelemetryAnomalyDetectionServiceTest {
+
+    private final TelemetryAnomalyDetectionService anomalyDetectionService =
+            new TelemetryAnomalyDetectionService();
+
+    @Test
+    @DisplayName("should classify normal telemetry event as not anomalous")
+    void shouldClassifyNormalTelemetryEventAsNotAnomalous() {
+        NormalizedTelemetryEvent event = normalizedEvent("temperature", new BigDecimal("28.4"));
+
+        TelemetryAnomalyResult result = anomalyDetectionService.detect(event);
+
+        assertThat(result.event()).isEqualTo(event);
+        assertThat(result.anomalous()).isFalse();
+        assertThat(result.severity()).isEqualTo(AnomalySeverity.NONE);
+        assertThat(result.reasons()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should detect high temperature anomaly")
+    void shouldDetectHighTemperatureAnomaly() {
+        NormalizedTelemetryEvent event = normalizedEvent("temperature", new BigDecimal("95.0"));
+
+        TelemetryAnomalyResult result = anomalyDetectionService.detect(event);
+
+        assertThat(result.anomalous()).isTrue();
+        assertThat(result.severity()).isEqualTo(AnomalySeverity.WARNING);
+        assertThat(result.reasons()).contains("temperature is above maximum threshold");
+    }
+
+    @Test
+    @DisplayName("should detect low temperature anomaly")
+    void shouldDetectLowTemperatureAnomaly() {
+        NormalizedTelemetryEvent event = normalizedEvent("temperature", new BigDecimal("-50.0"));
+
+        TelemetryAnomalyResult result = anomalyDetectionService.detect(event);
+
+        assertThat(result.anomalous()).isTrue();
+        assertThat(result.severity()).isEqualTo(AnomalySeverity.WARNING);
+        assertThat(result.reasons()).contains("temperature is below minimum threshold");
+    }
+
+    @Test
+    @DisplayName("should detect missing critical fields")
+    void shouldDetectMissingCriticalFields() {
+        NormalizedTelemetryEvent event = new NormalizedTelemetryEvent(
+                "evt-001",
+                null,
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                "",
+                "temperature-sensor",
+                null,
+                null,
+                "c",
+                "zone-a"
+        );
+
+        TelemetryAnomalyResult result = anomalyDetectionService.detect(event);
+
+        assertThat(result.anomalous()).isTrue();
+        assertThat(result.severity()).isEqualTo(AnomalySeverity.CRITICAL);
+        assertThat(result.reasons())
+                .contains(
+                        "tenantId is required",
+                        "deviceId is required",
+                        "metric is required",
+                        "value is required"
+                );
+    }
+
+    @Test
+    @DisplayName("should ignore temperature thresholds for unsupported metrics")
+    void shouldIgnoreTemperatureThresholdsForUnsupportedMetrics() {
+        NormalizedTelemetryEvent event = normalizedEvent("pressure", new BigDecimal("95.0"));
+
+        TelemetryAnomalyResult result = anomalyDetectionService.detect(event);
+
+        assertThat(result.anomalous()).isFalse();
+        assertThat(result.severity()).isEqualTo(AnomalySeverity.NONE);
+        assertThat(result.reasons()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should reject null normalized telemetry event")
+    void shouldRejectNullNormalizedTelemetryEvent() {
+        assertThatThrownBy(() -> anomalyDetectionService.detect(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("normalized telemetry event must not be null");
+    }
+
+    private NormalizedTelemetryEvent normalizedEvent(String metric, BigDecimal value) {
+        return new NormalizedTelemetryEvent(
+                "evt-001",
+                "factory-01",
+                "telemetry.reading",
+                Instant.parse("2026-03-31T12:00:00Z"),
+                "sensor-gateway",
+                "1.0",
+                "sensor-1042",
+                "temperature-sensor",
+                metric,
+                value,
+                "c",
+                "zone-a"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Add basic rule-based anomaly detection for normalized telemetry events in the telemetry-processor service.

## Related Issue
Closes #82

## Issue Requirements Covered
- Added simple threshold-based anomaly detection logic
- Added detection for missing critical telemetry fields
- Added a clear result model that distinguishes normal and anomalous events
- Integrated anomaly detection after normalization in the consumer flow
- Added tests for normal events, anomalous events, and invalid input

## Changes
- Added `AnomalySeverity`
- Added `TelemetryAnomalyResult`
- Added `TelemetryAnomalyDetectionService`
- Updated `TelemetryEventConsumer` to invoke anomaly detection after normalization
- Updated consumer test coverage for anomaly detection integration
- Added anomaly detection unit tests

## Testing
Ran telemetry-processor tests:

```bash
.\mvnw test
```

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Add rule-based anomaly detection into the telemetry-processor flow for normalized telemetry events.

New Features:
- Introduce TelemetryAnomalyDetectionService to classify normalized telemetry events as normal or anomalous based on simple validation and temperature thresholds.
- Add TelemetryAnomalyResult model and AnomalySeverity enum to represent anomaly classification outcomes and severity levels within the processor.

Enhancements:
- Update TelemetryEventConsumer to invoke anomaly detection after normalization, log anomalous events with severity and reasons, and skip further processing for anomalies.

Tests:
- Add unit tests for TelemetryAnomalyDetectionService covering normal events, threshold breaches, missing critical fields, unsupported metrics, and null input handling.
- Extend TelemetryEventConsumer tests to verify integration with the anomaly detection service and preserved behavior for invalid input.